### PR TITLE
feat: expose ordered critical path data (issue #85)

### DIFF
--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -11,7 +11,7 @@ from itertools import pairwise
 from typing import Literal, Mapping
 
 import networkx as nx  # type: ignore[import-untyped]
-from networkx import DiGraph, dag_longest_path_length
+from networkx import DiGraph, dag_longest_path, dag_longest_path_length
 from pydantic import AwareDatetime
 
 from taskdependencygraph.models.ids import TaskDependencyId, TaskId
@@ -23,6 +23,10 @@ from taskdependencygraph.models.task_dependency_update import (
 from taskdependencygraph.models.task_node import TaskNode
 from taskdependencygraph.models.task_node_as_artificial_endnode import task_node_as_artificial_endnode
 from taskdependencygraph.models.task_node_as_artificial_startnode import task_node_as_artificial_startnode
+
+_ARTIFICIAL_NODE_IDS: frozenset[TaskId] = frozenset(
+    {task_node_as_artificial_startnode.id, task_node_as_artificial_endnode.id}
+)
 
 
 class TaskDependencyGraph:
@@ -281,7 +285,7 @@ class TaskDependencyGraph:
         With this method it can be checked if a task is on the overall critical path, i.e. on the longest path
         between the first task and last task of this run.
         """
-        longest_path = nx.dag_longest_path(self._graph, weight="weight")  # The weight of the edge is the duration
+        longest_path = dag_longest_path(self._graph, weight="weight")  # The weight of the edge is the duration
         # of the task predecessor.
         # The longest path is the path, the sum of whose task durations is the greatest.
         # The longest_path is a list of their task ids as keys.
@@ -462,10 +466,7 @@ class TaskDependencyGraph:
         For a zero-duration milestone the finish time equals the start time.
         Raises ValueError if task_id is not a real task in this graph (unknown or artificial node IDs are rejected).
         """
-        if task_id not in self._graph.nodes or task_id in {
-            task_node_as_artificial_startnode.id,
-            task_node_as_artificial_endnode.id,
-        }:
+        if task_id not in self._graph.nodes or task_id in _ARTIFICIAL_NODE_IDS:
             raise ValueError(f"Task with id {task_id!r} is not a real task in this graph")
         task: TaskNode = self._graph.nodes[task_id]["domain_model"]
         return self.calculate_planned_starting_time_of_task(task_id) + task.planned_duration
@@ -474,20 +475,26 @@ class TaskDependencyGraph:
         """
         Returns the ordered list of task IDs on the critical path, from graph start to graph finish.
 
-        The path is determined by the same weighted-DAG semantics used by is_on_critical_path.
-        When multiple paths share the same total duration (tie), the result follows NetworkX's
-        deterministic graph-ordering: the path whose nodes appear earliest in insertion order wins.
-        Use a separate get_critical_path_task_id_paths() API (not yet implemented) if all tied
-        paths are needed.
+        Uses the same weighted-DAG semantics as is_on_critical_path: each directed edge carries the
+        duration of its predecessor node as weight. Tasks with an earliest_starttime may cause their
+        incoming edge weight to be stretched beyond the raw predecessor duration (see
+        _stretch_edges_with_successor_that_has_fixed_start), so wall-clock delays are reflected.
+
+        Tie-breaking: when multiple paths share the same total weight, the result follows NetworkX's
+        deterministic graph-insertion order (the path whose first differing node was inserted first
+        wins). Use a separate get_critical_path_task_id_paths() API (not yet implemented) if all
+        tied paths are needed.
+
+        Note: is_on_critical_path() does not filter artificial nodes, so calling it with an
+        artificial node ID may return True while that ID is absent from the default output here.
 
         By default artificial start/end node IDs are excluded. Pass include_artificial_nodes=True
         to include them (useful for debugging or advanced consumers).
         """
-        path: list[TaskId] = nx.dag_longest_path(self._graph, weight="weight")
+        path: list[TaskId] = dag_longest_path(self._graph, weight="weight")
         if include_artificial_nodes:
             return path
-        artificial = {task_node_as_artificial_startnode.id, task_node_as_artificial_endnode.id}
-        return [tid for tid in path if tid not in artificial]
+        return [tid for tid in path if tid not in _ARTIFICIAL_NODE_IDS]
 
     def get_critical_path_tasks(self, include_artificial_nodes: bool = False) -> list[TaskNode]:
         """
@@ -519,7 +526,7 @@ class TaskDependencyGraph:
         new_task_list = []
 
         for task_id in self._graph.nodes:
-            if task_id in {task_node_as_artificial_startnode.id, task_node_as_artificial_endnode.id}:
+            if task_id in _ARTIFICIAL_NODE_IDS:
                 continue
             task = self._graph.nodes[task_id]["domain_model"]
             copied_task = task.model_copy(

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -470,6 +470,37 @@ class TaskDependencyGraph:
         task: TaskNode = self._graph.nodes[task_id]["domain_model"]
         return self.calculate_planned_starting_time_of_task(task_id) + task.planned_duration
 
+    def get_critical_path_task_ids(self, include_artificial_nodes: bool = False) -> list[TaskId]:
+        """
+        Returns the ordered list of task IDs on the critical path, from graph start to graph finish.
+
+        The path is determined by the same weighted-DAG semantics used by is_on_critical_path.
+        When multiple paths share the same total duration (tie), the result follows NetworkX's
+        deterministic graph-ordering: the path whose nodes appear earliest in insertion order wins.
+        Use a separate get_critical_path_task_id_paths() API (not yet implemented) if all tied
+        paths are needed.
+
+        By default artificial start/end node IDs are excluded. Pass include_artificial_nodes=True
+        to include them (useful for debugging or advanced consumers).
+        """
+        path: list[TaskId] = nx.dag_longest_path(self._graph, weight="weight")
+        if include_artificial_nodes:
+            return path
+        artificial = {task_node_as_artificial_startnode.id, task_node_as_artificial_endnode.id}
+        return [tid for tid in path if tid not in artificial]
+
+    def get_critical_path_tasks(self, include_artificial_nodes: bool = False) -> list[TaskNode]:
+        """
+        Returns the ordered list of TaskNode objects on the critical path, from graph start to graph finish.
+
+        Convenience wrapper around get_critical_path_task_ids that resolves IDs to their domain models.
+        The include_artificial_nodes parameter has the same semantics as in get_critical_path_task_ids.
+        """
+        return [
+            self._graph.nodes[tid]["domain_model"]
+            for tid in self.get_critical_path_task_ids(include_artificial_nodes=include_artificial_nodes)
+        ]
+
     def calculate_planned_finish_time_of_graph(self) -> AwareDatetime:
         """
         Returns the planned finish time of the entire graph — the moment the last task completes.

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -13,7 +13,10 @@ from taskdependencygraph.models.task_node_as_artificial_endnode import (
     ID_OF_ARTIFICIAL_ENDNODE,
     task_node_as_artificial_endnode,
 )
-from taskdependencygraph.models.task_node_as_artificial_startnode import task_node_as_artificial_startnode
+from taskdependencygraph.models.task_node_as_artificial_startnode import (
+    ID_OF_ARTIFICIAL_STARTNODE,
+    task_node_as_artificial_startnode,
+)
 from taskdependencygraph.task_dependency_graph import TaskDependencyGraph
 
 from .example_data_for_test_task_dependency_graph import (
@@ -743,3 +746,114 @@ class TestPlannedFinishTimeOfGraph:
         long_ = _node("long", 40)
         tdg = TaskDependencyGraph(task_list=[short, long_], dependency_list=[], starting_time_of_run=_T0)
         assert tdg.calculate_planned_finish_time_of_graph() == _T0 + timedelta(minutes=40)
+
+
+# ---------------------------------------------------------------------------
+# Issue #85 – ordered critical path data
+# ---------------------------------------------------------------------------
+
+
+class TestGetCriticalPathTaskIds:
+    """Tests for get_critical_path_task_ids (issue #85)."""
+
+    def test_linear_graph_all_tasks_on_critical_path(self) -> None:
+        """In a linear chain every task is on the critical path, in order."""
+        a = _node("A", 10)
+        b = _node("B", 20)
+        c = _node("C", 5)
+        tdg = TaskDependencyGraph(
+            task_list=[a, b, c],
+            dependency_list=[_edge(a, b), _edge(b, c)],
+            starting_time_of_run=_T0,
+        )
+        ids = tdg.get_critical_path_task_ids()
+        assert ids == [a.id, b.id, c.id]
+
+    def test_parallel_paths_longer_path_wins(self) -> None:
+        """When two paths diverge, the longer one is on the critical path."""
+        start = _node("start", 5)
+        short = _node("short", 3)
+        long_ = _node("long", 30)
+        end = _node("end", 5)
+        tdg = TaskDependencyGraph(
+            task_list=[start, short, long_, end],
+            dependency_list=[_edge(start, short), _edge(start, long_), _edge(short, end), _edge(long_, end)],
+            starting_time_of_run=_T0,
+        )
+        ids = tdg.get_critical_path_task_ids()
+        assert start.id in ids
+        assert long_.id in ids
+        assert end.id in ids
+        assert short.id not in ids
+
+    def test_milestone_on_critical_path_is_included(self) -> None:
+        """A zero-duration milestone that lies on the critical path appears in the result."""
+        a = _node("A", 20)
+        ms = _node("MS", 0, milestone=True)
+        b = _node("B", 10)
+        tdg = TaskDependencyGraph(
+            task_list=[a, ms, b],
+            dependency_list=[_edge(a, ms), _edge(ms, b)],
+            starting_time_of_run=_T0,
+        )
+        ids = tdg.get_critical_path_task_ids()
+        assert ms.id in ids
+
+    def test_default_excludes_artificial_nodes(self) -> None:
+        """Artificial start/end nodes must not appear by default."""
+        a = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[a], dependency_list=[], starting_time_of_run=_T0)
+        ids = tdg.get_critical_path_task_ids()
+        assert ID_OF_ARTIFICIAL_STARTNODE not in ids
+        assert ID_OF_ARTIFICIAL_ENDNODE not in ids
+
+    def test_include_artificial_nodes_flag(self) -> None:
+        """Passing include_artificial_nodes=True makes artificial nodes appear at the boundaries."""
+        a = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[a], dependency_list=[], starting_time_of_run=_T0)
+        ids = tdg.get_critical_path_task_ids(include_artificial_nodes=True)
+        assert ids[0] == ID_OF_ARTIFICIAL_STARTNODE
+        assert ids[-1] == ID_OF_ARTIFICIAL_ENDNODE
+
+    def test_tie_behavior_is_deterministic(self) -> None:
+        """Equal-length parallel paths produce a deterministic (NetworkX-ordered) result."""
+        a = _node("A", 10)
+        b = _node("B", 10)
+        tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[], starting_time_of_run=_T0)
+        ids1 = tdg.get_critical_path_task_ids()
+        ids2 = tdg.get_critical_path_task_ids()
+        assert ids1 == ids2  # same graph, same result every call
+        assert len(ids1) == 1  # only one task in the path (both have equal weight; NetworkX picks one)
+
+
+class TestGetCriticalPathTasks:
+    """Tests for get_critical_path_tasks (issue #85)."""
+
+    def test_returns_task_nodes_in_order(self) -> None:
+        """get_critical_path_tasks returns TaskNode objects matching the ordered IDs."""
+        a = _node("A", 5)
+        b = _node("B", 15)
+        tdg = TaskDependencyGraph(
+            task_list=[a, b],
+            dependency_list=[_edge(a, b)],
+            starting_time_of_run=_T0,
+        )
+        tasks = tdg.get_critical_path_tasks()
+        assert [t.id for t in tasks] == tdg.get_critical_path_task_ids()
+
+    def test_default_excludes_artificial_task_nodes(self) -> None:
+        """Artificial TaskNode objects must not appear by default."""
+        a = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[a], dependency_list=[], starting_time_of_run=_T0)
+        tasks = tdg.get_critical_path_tasks()
+        task_ids = [t.id for t in tasks]
+        assert ID_OF_ARTIFICIAL_STARTNODE not in task_ids
+        assert ID_OF_ARTIFICIAL_ENDNODE not in task_ids
+
+    def test_include_artificial_nodes_flag(self) -> None:
+        """With include_artificial_nodes=True the first and last nodes are the artificial ones."""
+        a = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[a], dependency_list=[], starting_time_of_run=_T0)
+        tasks = tdg.get_critical_path_tasks(include_artificial_nodes=True)
+        assert tasks[0].id == ID_OF_ARTIFICIAL_STARTNODE
+        assert tasks[-1].id == ID_OF_ARTIFICIAL_ENDNODE

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -816,14 +816,33 @@ class TestGetCriticalPathTaskIds:
         assert ids[-1] == ID_OF_ARTIFICIAL_ENDNODE
 
     def test_tie_behavior_is_deterministic(self) -> None:
-        """Equal-length parallel paths produce a deterministic (NetworkX-ordered) result."""
+        """Equal-length parallel paths produce a deterministic (NetworkX-ordered) result.
+
+        NetworkX picks the path whose first differing node was inserted into the graph first,
+        which is `a` here. Two calls on the same graph must return the same list.
+        """
         a = _node("A", 10)
         b = _node("B", 10)
         tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[], starting_time_of_run=_T0)
         ids1 = tdg.get_critical_path_task_ids()
         ids2 = tdg.get_critical_path_task_ids()
-        assert ids1 == ids2  # same graph, same result every call
-        assert len(ids1) == 1  # only one task in the path (both have equal weight; NetworkX picks one)
+        assert ids1 == ids2
+        assert ids1 == [a.id]  # first-inserted node wins the tie
+
+    def test_empty_task_list_returns_empty_path(self) -> None:
+        """A graph with no real tasks returns an empty critical path."""
+        tdg = TaskDependencyGraph(task_list=[], dependency_list=[], starting_time_of_run=_T0)
+        assert tdg.get_critical_path_task_ids() == []
+
+    def test_earliest_starttime_stretches_onto_critical_path(self) -> None:
+        """A task delayed by earliest_starttime gets a stretched edge weight, pushing it onto the path."""
+        a = _node("A", 10)  # finishes at T0+10min, path weight 10
+        early = datetime(2024, 6, 1, 9, 0, 0, tzinfo=timezone.utc)  # T0 + 60min
+        b = _node("B", 10, earliest_start=early)  # edge stretched to 60min, path weight 70
+        tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[], starting_time_of_run=_T0)
+        ids = tdg.get_critical_path_task_ids()
+        assert b.id in ids
+        assert a.id not in ids
 
 
 class TestGetCriticalPathTasks:
@@ -857,3 +876,19 @@ class TestGetCriticalPathTasks:
         tasks = tdg.get_critical_path_tasks(include_artificial_nodes=True)
         assert tasks[0].id == ID_OF_ARTIFICIAL_STARTNODE
         assert tasks[-1].id == ID_OF_ARTIFICIAL_ENDNODE
+
+    def test_parallel_paths_longer_path_wins(self) -> None:
+        """TaskNode objects on the longer parallel path are returned, not the shorter one."""
+        short = _node("short", 5)
+        long_ = _node("long", 30)
+        end = _node("end", 5)
+        tdg = TaskDependencyGraph(
+            task_list=[short, long_, end],
+            dependency_list=[_edge(short, end), _edge(long_, end)],
+            starting_time_of_run=_T0,
+        )
+        tasks = tdg.get_critical_path_tasks()
+        task_ids = [t.id for t in tasks]
+        assert long_.id in task_ids
+        assert end.id in task_ids
+        assert short.id not in task_ids


### PR DESCRIPTION
## Summary

- Adds `get_critical_path_task_ids(include_artificial_nodes: bool = False) -> list[TaskId]`
- Adds `get_critical_path_tasks(include_artificial_nodes: bool = False) -> list[TaskNode]`
- Both return nodes ordered from graph start to finish using the same weighted-DAG semantics as `is_on_critical_path`
- Artificial start/end node IDs are excluded by default; pass `include_artificial_nodes=True` to include them
- Tie behavior (equal-length paths) follows NetworkX's deterministic graph-insertion order and is documented

## Test plan

- [x] Linear graph: all tasks appear in the correct order
- [x] Parallel paths: only the longer path is included
- [x] Milestone on critical path is included
- [x] Default call excludes artificial node IDs
- [x] `include_artificial_nodes=True` puts artificial nodes at boundaries
- [x] Equal-length tie produces a stable, deterministic result across calls
- [x] `get_critical_path_tasks` returns `TaskNode` objects whose IDs match `get_critical_path_task_ids`
- [x] Full suite: 72 passed, 0 regressions (4 pre-existing container errors unrelated)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)