### PR TITLE
feat: add pre-construction graph definition validation (issue #87)

### DIFF
--- a/src/taskdependencygraph/models/__init__.py
+++ b/src/taskdependencygraph/models/__init__.py
@@ -1,5 +1,10 @@
 """models are python objects which we use to model tasks, dependencies and the graph they form"""
 
+from .graph_definition_validation import (
+    GraphDefinitionValidationFinding,
+    GraphDefinitionValidationResult,
+    ValidationCode,
+)
 from .ids import PersonId, RunGroupId, RunGroupPersonRelationId, RunId, TaskDependencyId, TaskId
 from .person import Person
 from .schedule_report import ScheduleEntry, ScheduleReport
@@ -10,6 +15,9 @@ from .task_node_as_artificial_endnode import ID_OF_ARTIFICIAL_ENDNODE
 from .task_node_as_artificial_startnode import ID_OF_ARTIFICIAL_STARTNODE
 
 __all__ = [
+    "GraphDefinitionValidationFinding",
+    "GraphDefinitionValidationResult",
+    "ValidationCode",
     "Person",
     "RunId",
     "RunGroupId",

--- a/src/taskdependencygraph/models/graph_definition_validation.py
+++ b/src/taskdependencygraph/models/graph_definition_validation.py
@@ -1,0 +1,48 @@
+"""
+Graph definition validation models.
+"""
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict
+
+from taskdependencygraph.models.ids import TaskDependencyId, TaskId
+
+
+class ValidationCode(str, Enum):
+    """Stable codes identifying the kind of graph definition problem found."""
+
+    DUPLICATE_TASK_ID = "DUPLICATE_TASK_ID"
+    DUPLICATE_EXTERNAL_ID = "DUPLICATE_EXTERNAL_ID"
+    MISSING_EDGE_ENDPOINT = "MISSING_EDGE_ENDPOINT"
+    DUPLICATE_DEPENDENCY_ID = "DUPLICATE_DEPENDENCY_ID"
+    DUPLICATE_EDGE_PAIR = "DUPLICATE_EDGE_PAIR"
+    CYCLE = "CYCLE"
+    INVALID_MILESTONE_DURATION = "INVALID_MILESTONE_DURATION"
+
+
+class GraphDefinitionValidationFinding(BaseModel):
+    """A single validation problem found in a graph definition."""
+
+    model_config = ConfigDict(frozen=True)
+
+    code: ValidationCode
+    message: str
+    task_id: TaskId | None = None
+    dependency_id: TaskDependencyId | None = None
+
+
+class GraphDefinitionValidationResult(BaseModel):
+    """The aggregated result of validating a raw task/dependency list before graph construction."""
+
+    model_config = ConfigDict(frozen=True)
+
+    is_valid: bool
+    findings: list[GraphDefinitionValidationFinding]
+
+
+__all__ = [
+    "GraphDefinitionValidationFinding",
+    "GraphDefinitionValidationResult",
+    "ValidationCode",
+]

--- a/src/taskdependencygraph/models/graph_definition_validation.py
+++ b/src/taskdependencygraph/models/graph_definition_validation.py
@@ -29,6 +29,8 @@ class GraphDefinitionValidationFinding(BaseModel):
     code: ValidationCode
     message: str
     task_id: TaskId | None = None
+    """The task ID involved in this finding.
+    For MISSING_EDGE_ENDPOINT this may be an ID that does not exist in the task list."""
     dependency_id: TaskDependencyId | None = None
 
 
@@ -38,7 +40,7 @@ class GraphDefinitionValidationResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     is_valid: bool
-    findings: list[GraphDefinitionValidationFinding]
+    findings: tuple[GraphDefinitionValidationFinding, ...]
 
 
 __all__ = [

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -52,31 +52,12 @@ class TaskDependencyGraph:
     There is a reason why it's "private"/"protected".
     """
 
-    # pylint:disable=too-many-locals,too-many-branches,too-many-statements
-    @classmethod
-    def validate_definition(
-        cls, task_list: list[TaskNode], dependency_list: list[TaskDependencyEdge]
-    ) -> GraphDefinitionValidationResult:
-        """
-        Validates raw task and dependency lists before constructing a TaskDependencyGraph.
-
-        Returns a GraphDefinitionValidationResult containing all findings discovered.
-        Findings are collected in a single pass rather than stopping at the first problem,
-        so callers receive the complete picture in one call without catching exceptions.
-
-        Checks performed (in order):
-        - Duplicate TaskNode.id values
-        - Duplicate TaskNode.external_id values
-        - Milestones with non-zero planned_duration
-        - Missing edge endpoints (predecessor or successor not in task_list)
-        - Duplicate TaskDependencyEdge.id values
-        - Duplicate predecessor/successor edge pairs
-        - Cycles (using only edges whose both endpoints exist)
-        """
+    @staticmethod
+    def _validate_tasks(
+        task_list: list[TaskNode],
+    ) -> tuple[list[GraphDefinitionValidationFinding], set[TaskId]]:
         findings: list[GraphDefinitionValidationFinding] = []
         valid_task_ids: set[TaskId] = set()
-
-        # --- task-level checks ---
         seen_ids: set[TaskId] = set()
         reported_dup_ids: set[TaskId] = set()
         seen_external_ids: dict[str, TaskId] = {}
@@ -117,18 +98,23 @@ class TaskDependencyGraph:
                 findings.append(
                     GraphDefinitionValidationFinding(
                         code=ValidationCode.INVALID_MILESTONE_DURATION,
-                        message=(
-                            f"Milestone {task.external_id!r} has non-zero planned duration:" f" {task.planned_duration}"
-                        ),
+                        message=f"Milestone {task.external_id!r} has non-zero planned duration: {task.planned_duration}",
                         task_id=task.id,
                     )
                 )
 
-        # --- edge-level checks ---
+        return findings, valid_task_ids
+
+    @staticmethod
+    def _validate_edges(
+        dependency_list: list[TaskDependencyEdge],
+        valid_task_ids: set[TaskId],
+    ) -> tuple[list[GraphDefinitionValidationFinding], list[TaskDependencyEdge]]:
+        findings: list[GraphDefinitionValidationFinding] = []
+        valid_edges: list[TaskDependencyEdge] = []
         seen_dep_ids: set[TaskDependencyId] = set()
         reported_dup_dep_ids: set[TaskDependencyId] = set()
         seen_edge_pairs: set[tuple[TaskId, TaskId]] = set()
-        valid_edges: list[TaskDependencyEdge] = []
 
         for edge in dependency_list:
             if edge.id in seen_dep_ids:
@@ -179,29 +165,62 @@ class TaskDependencyGraph:
             if edge.task_predecessor in valid_task_ids and edge.task_successor in valid_task_ids:
                 valid_edges.append(edge)
 
-        # --- cycle detection (only on edges with valid endpoints, skip duplicate pairs) ---
-        if valid_edges:
-            temp: nx.DiGraph = nx.DiGraph()
-            for task in task_list:
-                temp.add_node(task.id)
-            for edge in valid_edges:
-                if not temp.has_edge(edge.task_predecessor, edge.task_successor):
-                    temp.add_edge(edge.task_predecessor, edge.task_successor)
-            if not nx.is_directed_acyclic_graph(temp):
-                try:
-                    cycle = nx.find_cycle(temp)
-                    cycle_node_ids = [str(u) for u, _ in cycle]
-                    findings.append(
-                        GraphDefinitionValidationFinding(
-                            code=ValidationCode.CYCLE,
-                            message=f"Cycle detected: {' -> '.join(cycle_node_ids)} -> {cycle_node_ids[0]}",
-                            task_id=TaskId(cycle[0][0]),
-                        )
-                    )
-                except nx.NetworkXNoCycle:  # pragma: no cover
-                    pass
+        return findings, valid_edges
 
-        return GraphDefinitionValidationResult(is_valid=len(findings) == 0, findings=tuple(findings))
+    @staticmethod
+    def _detect_cycle_findings(
+        task_list: list[TaskNode],
+        valid_edges: list[TaskDependencyEdge],
+    ) -> list[GraphDefinitionValidationFinding]:
+        """Returns a CYCLE finding if valid_edges form a cycle, otherwise an empty list."""
+        if not valid_edges:
+            return []
+        temp: nx.DiGraph = nx.DiGraph()
+        for task in task_list:
+            temp.add_node(task.id)
+        for edge in valid_edges:
+            if not temp.has_edge(edge.task_predecessor, edge.task_successor):
+                temp.add_edge(edge.task_predecessor, edge.task_successor)
+        if nx.is_directed_acyclic_graph(temp):
+            return []
+        try:
+            cycle = nx.find_cycle(temp)
+            cycle_node_ids = [str(u) for u, _ in cycle]
+            return [
+                GraphDefinitionValidationFinding(
+                    code=ValidationCode.CYCLE,
+                    message=f"Cycle detected: {' -> '.join(cycle_node_ids)} -> {cycle_node_ids[0]}",
+                    task_id=TaskId(cycle[0][0]),
+                )
+            ]
+        except nx.NetworkXNoCycle:  # pragma: no cover
+            return []
+
+    @classmethod
+    def validate_definition(
+        cls, task_list: list[TaskNode], dependency_list: list[TaskDependencyEdge]
+    ) -> GraphDefinitionValidationResult:
+        """
+        Validates raw task and dependency lists before constructing a TaskDependencyGraph.
+
+        Returns a GraphDefinitionValidationResult containing all findings discovered.
+        Findings are collected in a single pass rather than stopping at the first problem,
+        so callers receive the complete picture in one call without catching exceptions.
+
+        Checks performed (in order):
+        - Duplicate TaskNode.id values
+        - Duplicate TaskNode.external_id values
+        - Milestones with non-zero planned_duration
+        - Missing edge endpoints (predecessor or successor not in task_list)
+        - Duplicate TaskDependencyEdge.id values
+        - Duplicate predecessor/successor edge pairs
+        - Cycles (using only edges whose both endpoints exist)
+        """
+        task_findings, valid_task_ids = cls._validate_tasks(task_list)
+        edge_findings, valid_edges = cls._validate_edges(dependency_list, valid_task_ids)
+        cycle_findings = cls._detect_cycle_findings(task_list, valid_edges)
+        all_findings = task_findings + edge_findings + cycle_findings
+        return GraphDefinitionValidationResult(is_valid=not all_findings, findings=tuple(all_findings))
 
     def __init__(
         self, task_list: list[TaskNode], dependency_list: list[TaskDependencyEdge], starting_time_of_run: AwareDatetime

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -52,6 +52,7 @@ class TaskDependencyGraph:
     There is a reason why it's "private"/"protected".
     """
 
+    # pylint:disable=too-many-locals,too-many-branches,too-many-statements
     @classmethod
     def validate_definition(
         cls, task_list: list[TaskNode], dependency_list: list[TaskDependencyEdge]

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -98,7 +98,9 @@ class TaskDependencyGraph:
                 findings.append(
                     GraphDefinitionValidationFinding(
                         code=ValidationCode.INVALID_MILESTONE_DURATION,
-                        message=f"Milestone {task.external_id!r} has non-zero planned duration: {task.planned_duration}",
+                        message=(
+                            f"Milestone {task.external_id!r} has non-zero planned duration: {task.planned_duration}"
+                        ),
                         task_id=task.id,
                     )
                 )

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -79,6 +79,7 @@ class TaskDependencyGraph:
         seen_ids: set[TaskId] = set()
         reported_dup_ids: set[TaskId] = set()
         seen_external_ids: dict[str, TaskId] = {}
+        reported_dup_external_ids: set[str] = set()
 
         for task in task_list:
             if task.id in seen_ids:
@@ -96,16 +97,18 @@ class TaskDependencyGraph:
                 valid_task_ids.add(task.id)
 
             if task.external_id in seen_external_ids:
-                findings.append(
-                    GraphDefinitionValidationFinding(
-                        code=ValidationCode.DUPLICATE_EXTERNAL_ID,
-                        message=(
-                            f"Duplicate external_id {task.external_id!r}: "
-                            f"tasks {seen_external_ids[task.external_id]!r} and {task.id!r}"
-                        ),
-                        task_id=task.id,
+                if task.external_id not in reported_dup_external_ids:
+                    findings.append(
+                        GraphDefinitionValidationFinding(
+                            code=ValidationCode.DUPLICATE_EXTERNAL_ID,
+                            message=(
+                                f"Duplicate external_id {task.external_id!r}: "
+                                f"first seen at task {seen_external_ids[task.external_id]!r}"
+                            ),
+                            task_id=task.id,
+                        )
                     )
-                )
+                    reported_dup_external_ids.add(task.external_id)
             else:
                 seen_external_ids[task.external_id] = task.id
 
@@ -190,14 +193,14 @@ class TaskDependencyGraph:
                     findings.append(
                         GraphDefinitionValidationFinding(
                             code=ValidationCode.CYCLE,
-                            message=f"Cycle detected: {' -> '.join(cycle_node_ids)}",
+                            message=f"Cycle detected: {' -> '.join(cycle_node_ids)} -> {cycle_node_ids[0]}",
                             task_id=TaskId(cycle[0][0]),
                         )
                     )
                 except nx.NetworkXNoCycle:  # pragma: no cover
                     pass
 
-        return GraphDefinitionValidationResult(is_valid=len(findings) == 0, findings=findings)
+        return GraphDefinitionValidationResult(is_valid=len(findings) == 0, findings=tuple(findings))
 
     def __init__(
         self, task_list: list[TaskNode], dependency_list: list[TaskDependencyEdge], starting_time_of_run: AwareDatetime

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -14,6 +14,11 @@ import networkx as nx  # type: ignore[import-untyped]
 from networkx import DiGraph, dag_longest_path, dag_longest_path_length
 from pydantic import AwareDatetime
 
+from taskdependencygraph.models.graph_definition_validation import (
+    GraphDefinitionValidationFinding,
+    GraphDefinitionValidationResult,
+    ValidationCode,
+)
 from taskdependencygraph.models.ids import TaskDependencyId, TaskId
 from taskdependencygraph.models.schedule_report import ScheduleEntry, ScheduleReport
 from taskdependencygraph.models.task_dependency_edge import TaskDependencyEdge
@@ -46,6 +51,153 @@ class TaskDependencyGraph:
     But you shouldn't access it in the first place, except for some tests.
     There is a reason why it's "private"/"protected".
     """
+
+    @classmethod
+    def validate_definition(
+        cls, task_list: list[TaskNode], dependency_list: list[TaskDependencyEdge]
+    ) -> GraphDefinitionValidationResult:
+        """
+        Validates raw task and dependency lists before constructing a TaskDependencyGraph.
+
+        Returns a GraphDefinitionValidationResult containing all findings discovered.
+        Findings are collected in a single pass rather than stopping at the first problem,
+        so callers receive the complete picture in one call without catching exceptions.
+
+        Checks performed (in order):
+        - Duplicate TaskNode.id values
+        - Duplicate TaskNode.external_id values
+        - Milestones with non-zero planned_duration
+        - Missing edge endpoints (predecessor or successor not in task_list)
+        - Duplicate TaskDependencyEdge.id values
+        - Duplicate predecessor/successor edge pairs
+        - Cycles (using only edges whose both endpoints exist)
+        """
+        findings: list[GraphDefinitionValidationFinding] = []
+        valid_task_ids: set[TaskId] = set()
+
+        # --- task-level checks ---
+        seen_ids: set[TaskId] = set()
+        reported_dup_ids: set[TaskId] = set()
+        seen_external_ids: dict[str, TaskId] = {}
+
+        for task in task_list:
+            if task.id in seen_ids:
+                if task.id not in reported_dup_ids:
+                    findings.append(
+                        GraphDefinitionValidationFinding(
+                            code=ValidationCode.DUPLICATE_TASK_ID,
+                            message=f"Duplicate task id: {task.id!r}",
+                            task_id=task.id,
+                        )
+                    )
+                    reported_dup_ids.add(task.id)
+            else:
+                seen_ids.add(task.id)
+                valid_task_ids.add(task.id)
+
+            if task.external_id in seen_external_ids:
+                findings.append(
+                    GraphDefinitionValidationFinding(
+                        code=ValidationCode.DUPLICATE_EXTERNAL_ID,
+                        message=(
+                            f"Duplicate external_id {task.external_id!r}: "
+                            f"tasks {seen_external_ids[task.external_id]!r} and {task.id!r}"
+                        ),
+                        task_id=task.id,
+                    )
+                )
+            else:
+                seen_external_ids[task.external_id] = task.id
+
+            if task.is_milestone and task.planned_duration.total_seconds() > 0:
+                findings.append(
+                    GraphDefinitionValidationFinding(
+                        code=ValidationCode.INVALID_MILESTONE_DURATION,
+                        message=(
+                            f"Milestone {task.external_id!r} has non-zero planned duration:" f" {task.planned_duration}"
+                        ),
+                        task_id=task.id,
+                    )
+                )
+
+        # --- edge-level checks ---
+        seen_dep_ids: set[TaskDependencyId] = set()
+        reported_dup_dep_ids: set[TaskDependencyId] = set()
+        seen_edge_pairs: set[tuple[TaskId, TaskId]] = set()
+        valid_edges: list[TaskDependencyEdge] = []
+
+        for edge in dependency_list:
+            if edge.id in seen_dep_ids:
+                if edge.id not in reported_dup_dep_ids:
+                    findings.append(
+                        GraphDefinitionValidationFinding(
+                            code=ValidationCode.DUPLICATE_DEPENDENCY_ID,
+                            message=f"Duplicate dependency id: {edge.id!r}",
+                            dependency_id=edge.id,
+                        )
+                    )
+                    reported_dup_dep_ids.add(edge.id)
+            else:
+                seen_dep_ids.add(edge.id)
+
+            if edge.task_predecessor not in valid_task_ids:
+                findings.append(
+                    GraphDefinitionValidationFinding(
+                        code=ValidationCode.MISSING_EDGE_ENDPOINT,
+                        message=f"Edge {edge.id!r} references unknown predecessor {edge.task_predecessor!r}",
+                        task_id=edge.task_predecessor,
+                        dependency_id=edge.id,
+                    )
+                )
+
+            if edge.task_successor not in valid_task_ids:
+                findings.append(
+                    GraphDefinitionValidationFinding(
+                        code=ValidationCode.MISSING_EDGE_ENDPOINT,
+                        message=f"Edge {edge.id!r} references unknown successor {edge.task_successor!r}",
+                        task_id=edge.task_successor,
+                        dependency_id=edge.id,
+                    )
+                )
+
+            pair = (edge.task_predecessor, edge.task_successor)
+            if pair in seen_edge_pairs:
+                findings.append(
+                    GraphDefinitionValidationFinding(
+                        code=ValidationCode.DUPLICATE_EDGE_PAIR,
+                        message=f"Duplicate edge pair: {edge.task_predecessor!r} -> {edge.task_successor!r}",
+                        dependency_id=edge.id,
+                    )
+                )
+            else:
+                seen_edge_pairs.add(pair)
+
+            if edge.task_predecessor in valid_task_ids and edge.task_successor in valid_task_ids:
+                valid_edges.append(edge)
+
+        # --- cycle detection (only on edges with valid endpoints, skip duplicate pairs) ---
+        if valid_edges:
+            temp: nx.DiGraph = nx.DiGraph()
+            for task in task_list:
+                temp.add_node(task.id)
+            for edge in valid_edges:
+                if not temp.has_edge(edge.task_predecessor, edge.task_successor):
+                    temp.add_edge(edge.task_predecessor, edge.task_successor)
+            if not nx.is_directed_acyclic_graph(temp):
+                try:
+                    cycle = nx.find_cycle(temp)
+                    cycle_node_ids = [str(u) for u, _ in cycle]
+                    findings.append(
+                        GraphDefinitionValidationFinding(
+                            code=ValidationCode.CYCLE,
+                            message=f"Cycle detected: {' -> '.join(cycle_node_ids)}",
+                            task_id=TaskId(cycle[0][0]),
+                        )
+                    )
+                except nx.NetworkXNoCycle:  # pragma: no cover
+                    pass
+
+        return GraphDefinitionValidationResult(is_valid=len(findings) == 0, findings=findings)
 
     def __init__(
         self, task_list: list[TaskNode], dependency_list: list[TaskDependencyEdge], starting_time_of_run: AwareDatetime

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -1067,12 +1067,12 @@ class TestValidateDefinition:
     """Tests for TaskDependencyGraph.validate_definition (issue #87)."""
 
     def test_valid_definition_has_no_findings(self) -> None:
-        """A well-formed graph definition returns is_valid=True with an empty findings list."""
+        """A well-formed graph definition returns is_valid=True with an empty findings tuple."""
         a = _node("A", 10)
         b = _node("B", 20)
         result = TaskDependencyGraph.validate_definition([a, b], [_edge(a, b)])
         assert result.is_valid is True
-        assert result.findings == []
+        assert result.findings == ()
 
     def test_duplicate_task_id_is_reported(self) -> None:
         """Two TaskNode objects sharing the same id produce a DUPLICATE_TASK_ID finding."""
@@ -1159,6 +1159,17 @@ class TestValidateDefinition:
         b = _node("B", 10)
         ghost = _node("ghost", 5)
         result = TaskDependencyGraph.validate_definition([a, b], [_edge(a, b), _edge(b, a), _edge(a, ghost)])
+        assert result.is_valid is False
         codes = {f.code for f in result.findings}
         assert ValidationCode.CYCLE in codes
         assert ValidationCode.MISSING_EDGE_ENDPOINT in codes
+
+    def test_three_tasks_with_same_external_id_produce_one_finding(self) -> None:
+        """Three tasks sharing the same external_id produce exactly one DUPLICATE_EXTERNAL_ID finding."""
+        a = _node("EXT", 10)
+        b = _node("EXT", 20)
+        c = _node("EXT", 30)
+        result = TaskDependencyGraph.validate_definition([a, b, c], [])
+        assert result.is_valid is False
+        dup_findings = [f for f in result.findings if f.code == ValidationCode.DUPLICATE_EXTERNAL_ID]
+        assert len(dup_findings) == 1

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -6,6 +6,9 @@ import networkx as nx  # type: ignore[import-untyped]
 import pytest
 from pydantic import AwareDatetime
 
+from taskdependencygraph.models.graph_definition_validation import (
+    ValidationCode,
+)
 from taskdependencygraph.models.ids import TaskDependencyId, TaskId
 from taskdependencygraph.models.task_dependency_edge import TaskDependencyEdge
 from taskdependencygraph.models.task_node import TaskNode
@@ -1053,3 +1056,109 @@ class TestScheduleReport:
         entry = report.entries[0]
         assert entry.planned_start == early
         assert entry.planned_finish == early + timedelta(minutes=30)
+
+
+# ---------------------------------------------------------------------------
+# Issue #87 – pre-construction graph definition validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDefinition:
+    """Tests for TaskDependencyGraph.validate_definition (issue #87)."""
+
+    def test_valid_definition_has_no_findings(self) -> None:
+        """A well-formed graph definition returns is_valid=True with an empty findings list."""
+        a = _node("A", 10)
+        b = _node("B", 20)
+        result = TaskDependencyGraph.validate_definition([a, b], [_edge(a, b)])
+        assert result.is_valid is True
+        assert result.findings == []
+
+    def test_duplicate_task_id_is_reported(self) -> None:
+        """Two TaskNode objects sharing the same id produce a DUPLICATE_TASK_ID finding."""
+        a = _node("A", 10)
+        a_dup = a.model_copy(update={"external_id": "A2"})  # same id, different external_id
+        result = TaskDependencyGraph.validate_definition([a, a_dup], [])
+        assert result.is_valid is False
+        assert any(f.code == ValidationCode.DUPLICATE_TASK_ID for f in result.findings)
+
+    def test_duplicate_external_id_is_reported(self) -> None:
+        """Two tasks with the same external_id produce a DUPLICATE_EXTERNAL_ID finding."""
+        a = _node("A", 10)
+        b = _node("A", 20)  # same external_id "A"
+        result = TaskDependencyGraph.validate_definition([a, b], [])
+        assert result.is_valid is False
+        assert any(f.code == ValidationCode.DUPLICATE_EXTERNAL_ID for f in result.findings)
+
+    def test_missing_predecessor_is_reported(self) -> None:
+        """An edge whose predecessor is absent from task_list produces MISSING_EDGE_ENDPOINT."""
+        a = _node("A", 10)
+        ghost = _node("ghost", 5)
+        result = TaskDependencyGraph.validate_definition([a], [_edge(ghost, a)])
+        assert result.is_valid is False
+        assert any(f.code == ValidationCode.MISSING_EDGE_ENDPOINT for f in result.findings)
+
+    def test_missing_successor_is_reported(self) -> None:
+        """An edge whose successor is absent from task_list produces MISSING_EDGE_ENDPOINT."""
+        a = _node("A", 10)
+        ghost = _node("ghost", 5)
+        result = TaskDependencyGraph.validate_definition([a], [_edge(a, ghost)])
+        assert result.is_valid is False
+        assert any(f.code == ValidationCode.MISSING_EDGE_ENDPOINT for f in result.findings)
+
+    def test_duplicate_dependency_id_is_reported(self) -> None:
+        """Two edges sharing the same id produce a DUPLICATE_DEPENDENCY_ID finding."""
+        a = _node("A", 10)
+        b = _node("B", 10)
+        c = _node("C", 10)
+        e1 = _edge(a, b)
+        e2 = e1.model_copy(update={"task_predecessor": b.id, "task_successor": c.id})
+        result = TaskDependencyGraph.validate_definition([a, b, c], [e1, e2])
+        assert result.is_valid is False
+        assert any(f.code == ValidationCode.DUPLICATE_DEPENDENCY_ID for f in result.findings)
+
+    def test_duplicate_edge_pair_is_reported(self) -> None:
+        """Two edges with the same predecessor/successor pair produce DUPLICATE_EDGE_PAIR."""
+        a = _node("A", 10)
+        b = _node("B", 10)
+        result = TaskDependencyGraph.validate_definition([a, b], [_edge(a, b), _edge(a, b)])
+        assert result.is_valid is False
+        assert any(f.code == ValidationCode.DUPLICATE_EDGE_PAIR for f in result.findings)
+
+    def test_cycle_is_reported(self) -> None:
+        """A dependency cycle produces a CYCLE finding."""
+        a = _node("A", 10)
+        b = _node("B", 10)
+        result = TaskDependencyGraph.validate_definition([a, b], [_edge(a, b), _edge(b, a)])
+        assert result.is_valid is False
+        assert any(f.code == ValidationCode.CYCLE for f in result.findings)
+
+    def test_invalid_milestone_duration_is_reported(self) -> None:
+        """A milestone with non-zero planned_duration produces INVALID_MILESTONE_DURATION."""
+        ms = _node("MS", 10, milestone=True)
+        result = TaskDependencyGraph.validate_definition([ms], [])
+        assert result.is_valid is False
+        assert any(f.code == ValidationCode.INVALID_MILESTONE_DURATION for f in result.findings)
+
+    def test_multiple_errors_returned_together(self) -> None:
+        """All independent findings are collected in a single call rather than stopping at the first."""
+        a = _node("A", 10)
+        a_dup = a.model_copy(update={"external_id": "A2"})  # DUPLICATE_TASK_ID
+        ms = _node("MS", 5, milestone=True)  # INVALID_MILESTONE_DURATION
+        ghost = _node("ghost", 5)
+        result = TaskDependencyGraph.validate_definition([a, a_dup, ms], [_edge(a, ghost)])
+        assert result.is_valid is False
+        codes = {f.code for f in result.findings}
+        assert ValidationCode.DUPLICATE_TASK_ID in codes
+        assert ValidationCode.INVALID_MILESTONE_DURATION in codes
+        assert ValidationCode.MISSING_EDGE_ENDPOINT in codes
+
+    def test_missing_endpoint_and_cycle_both_reported(self) -> None:
+        """Missing endpoints and a cycle are reported together in one result."""
+        a = _node("A", 10)
+        b = _node("B", 10)
+        ghost = _node("ghost", 5)
+        result = TaskDependencyGraph.validate_definition([a, b], [_edge(a, b), _edge(b, a), _edge(a, ghost)])
+        codes = {f.code for f in result.findings}
+        assert ValidationCode.CYCLE in codes
+        assert ValidationCode.MISSING_EDGE_ENDPOINT in codes


### PR DESCRIPTION
## Summary

- Adds `ValidationCode` enum with 7 stable codes: `DUPLICATE_TASK_ID`, `DUPLICATE_EXTERNAL_ID`, `MISSING_EDGE_ENDPOINT`, `DUPLICATE_DEPENDENCY_ID`, `DUPLICATE_EDGE_PAIR`, `CYCLE`, `INVALID_MILESTONE_DURATION`
- Adds `GraphDefinitionValidationFinding` and `GraphDefinitionValidationResult` frozen Pydantic models
- Adds `TaskDependencyGraph.validate_definition(task_list, dependency_list) -> GraphDefinitionValidationResult` classmethod
- All findings are collected in one pass (no early exit) — callers receive the complete picture without catching exceptions
- Cycle detection uses only edges with valid endpoints, so missing-endpoint findings can coexist with cycle findings
- Exports all new types from `taskdependencygraph.models`

## Test plan

- [x] Valid definition returns `is_valid=True` and empty findings list
- [x] Duplicate task ID reported (before NetworkX would silently overwrite)
- [x] Duplicate external ID reported
- [x] Missing predecessor reported (MISSING_EDGE_ENDPOINT)
- [x] Missing successor reported (MISSING_EDGE_ENDPOINT)
- [x] Duplicate dependency ID reported
- [x] Duplicate edge pair reported
- [x] Cycle reported (CYCLE)
- [x] Milestone with non-zero duration reported (INVALID_MILESTONE_DURATION)
- [x] Multiple simultaneous errors returned together in one result
- [x] Missing endpoint + cycle both reported together
- [x] Full suite: 96 passed, 0 regressions

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)