### PR TITLE
feat: add total slack calculation per task (issue #88)

### DIFF
--- a/src/taskdependencygraph/models/schedule_report.py
+++ b/src/taskdependencygraph/models/schedule_report.py
@@ -25,6 +25,8 @@ class ScheduleEntry(BaseModel):
     planned_duration: timedelta
     is_milestone: bool
     is_on_critical_path: bool
+    total_slack: timedelta
+    """Maximum delay the task can absorb without pushing out the graph finish time."""
     predecessor_task_ids: list[TaskId]
     successor_task_ids: list[TaskId]
 

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -725,6 +725,9 @@ class TaskDependencyGraph:
 
         Raises ValueError for unknown task IDs and for the internal artificial start/end nodes,
         which are not part of the public API.
+
+        Note: each call runs a full backward pass (O(V+E)). For bulk queries over all tasks,
+        prefer create_schedule_report() which amortises the backward pass across all entries.
         """
         if task_id not in self._graph.nodes or task_id in _ARTIFICIAL_NODE_IDS:
             raise ValueError(f"Task with id {task_id!r} is not a real task in this graph")
@@ -777,9 +780,6 @@ class TaskDependencyGraph:
                 if task_id not in _ARTIFICIAL_NODE_IDS
                 else planned_start + task.planned_duration
             )
-            earliest_start = planned_start - self._starting_time_of_run
-            total_slack = latest_start_cache[task_id] - earliest_start
-
             predecessor_ids = sorted(
                 [
                     pid
@@ -809,7 +809,7 @@ class TaskDependencyGraph:
                     planned_duration=task.planned_duration,
                     is_milestone=task.is_milestone,
                     is_on_critical_path=task_id in critical_path_set,
-                    total_slack=total_slack,
+                    total_slack=latest_start_cache[task_id] - (planned_start - self._starting_time_of_run),
                     predecessor_task_ids=predecessor_ids,
                     successor_task_ids=successor_ids,
                 )

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -686,26 +686,25 @@ class TaskDependencyGraph:
             for tid in self.get_critical_path_task_ids(include_artificial_nodes=include_artificial_nodes)
         ]
 
-    def _compute_ls_minutes(self) -> dict[TaskId, float]:
+    def _compute_latest_start(self) -> dict[TaskId, timedelta]:
         """
-        Backward pass: returns the latest-start time (minutes from graph start) for every node.
+        Backward pass: returns the latest-start offset (from graph start) for every node.
 
         Processes nodes in reverse topological order. For each node the latest finish is the
         minimum latest-start of all direct successors; latest start = latest finish − duration.
         Uses only planned_duration (not stretched edge weights) so that waiting time introduced
         by earliest_starttime on a successor is correctly reflected as slack for its predecessors.
         """
-        graph_finish_minutes: float = dag_longest_path_length(self._graph, weight="weight")
-        ls_minutes: dict[TaskId, float] = {}
+        graph_finish: timedelta = timedelta(minutes=dag_longest_path_length(self._graph, weight="weight"))
+        latest_start: dict[TaskId, timedelta] = {}
         for node in reversed(list(nx.topological_sort(self._graph))):
             successors = list(self._graph.successors(node))
             if not successors:
-                ls_minutes[node] = graph_finish_minutes
+                latest_start[node] = graph_finish
             else:
-                lf = min(ls_minutes[s] for s in successors)
-                duration_min = self._graph.nodes[node]["domain_model"].planned_duration.total_seconds() / 60
-                ls_minutes[node] = lf - duration_min
-        return ls_minutes
+                latest_finish = min(latest_start[s] for s in successors)
+                latest_start[node] = latest_finish - self._graph.nodes[node]["domain_model"].planned_duration
+        return latest_start
 
     def calculate_total_slack_of_task(self, task_id: TaskId) -> timedelta:
         """
@@ -716,7 +715,7 @@ class TaskDependencyGraph:
         the whole graph. A positive value means the task can absorb that much delay without
         affecting the graph finish.
 
-        Computed via a backward pass through the DAG (see _compute_ls_minutes): for each node
+        Computed via a backward pass through the DAG (see _compute_latest_start): for each node
         the latest allowable finish (LF) equals the minimum of the latest starts of all direct
         successors, and latest start (LS) = LF − planned_duration. Total slack = LS − ES, where
         ES is the existing planned-start calculation. Crucially, the backward pass uses only
@@ -729,11 +728,9 @@ class TaskDependencyGraph:
         """
         if task_id not in self._graph.nodes or task_id in _ARTIFICIAL_NODE_IDS:
             raise ValueError(f"Task with id {task_id!r} is not a real task in this graph")
-        ls_minutes = self._compute_ls_minutes()
-        es_minutes = (
-            self.calculate_planned_starting_time_of_task(task_id) - self._starting_time_of_run
-        ).total_seconds() / 60
-        return timedelta(minutes=ls_minutes[task_id] - es_minutes)
+        latest_start = self._compute_latest_start()
+        earliest_start = self.calculate_planned_starting_time_of_task(task_id) - self._starting_time_of_run
+        return latest_start[task_id] - earliest_start
 
     def calculate_planned_finish_time_of_graph(self) -> AwareDatetime:
         """
@@ -759,11 +756,11 @@ class TaskDependencyGraph:
         critical_path_ids = self.get_critical_path_task_ids(include_artificial_nodes=include_artificial_nodes)
         critical_path_set = set(critical_path_ids)
 
-        # Pre-compute all start times and latest-start times once to avoid repeated DAG traversals.
+        # Pre-compute all start times and latest-start offsets once to avoid repeated DAG traversals.
         start_cache: dict[TaskId, AwareDatetime] = {
             tid: self.calculate_planned_starting_time_of_task(tid) for tid in self._graph.nodes
         }
-        ls_minutes_cache: dict[TaskId, float] = self._compute_ls_minutes()
+        latest_start_cache: dict[TaskId, timedelta] = self._compute_latest_start()
 
         def _task_sort_key(tid: TaskId) -> tuple[AwareDatetime, str, str]:
             task: TaskNode = self._graph.nodes[tid]["domain_model"]
@@ -780,8 +777,8 @@ class TaskDependencyGraph:
                 if task_id not in _ARTIFICIAL_NODE_IDS
                 else planned_start + task.planned_duration
             )
-            es_minutes = (planned_start - self._starting_time_of_run).total_seconds() / 60
-            total_slack = timedelta(minutes=ls_minutes_cache[task_id] - es_minutes)
+            earliest_start = planned_start - self._starting_time_of_run
+            total_slack = latest_start_cache[task_id] - earliest_start
 
             predecessor_ids = sorted(
                 [

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -686,6 +686,55 @@ class TaskDependencyGraph:
             for tid in self.get_critical_path_task_ids(include_artificial_nodes=include_artificial_nodes)
         ]
 
+    def _compute_ls_minutes(self) -> dict[TaskId, float]:
+        """
+        Backward pass: returns the latest-start time (minutes from graph start) for every node.
+
+        Processes nodes in reverse topological order. For each node the latest finish is the
+        minimum latest-start of all direct successors; latest start = latest finish − duration.
+        Uses only planned_duration (not stretched edge weights) so that waiting time introduced
+        by earliest_starttime on a successor is correctly reflected as slack for its predecessors.
+        """
+        graph_finish_minutes: float = dag_longest_path_length(self._graph, weight="weight")
+        ls_minutes: dict[TaskId, float] = {}
+        for node in reversed(list(nx.topological_sort(self._graph))):
+            successors = list(self._graph.successors(node))
+            if not successors:
+                ls_minutes[node] = graph_finish_minutes
+            else:
+                lf = min(ls_minutes[s] for s in successors)
+                duration_min = self._graph.nodes[node]["domain_model"].planned_duration.total_seconds() / 60
+                ls_minutes[node] = lf - duration_min
+        return ls_minutes
+
+    def calculate_total_slack_of_task(self, task_id: TaskId) -> timedelta:
+        """
+        Returns the total slack of a task: the maximum amount of time by which the task's
+        planned start (or finish) can be delayed without pushing out the graph finish time.
+
+        A value of zero means the task lies on a critical path — any delay immediately delays
+        the whole graph. A positive value means the task can absorb that much delay without
+        affecting the graph finish.
+
+        Computed via a backward pass through the DAG (see _compute_ls_minutes): for each node
+        the latest allowable finish (LF) equals the minimum of the latest starts of all direct
+        successors, and latest start (LS) = LF − planned_duration. Total slack = LS − ES, where
+        ES is the existing planned-start calculation. Crucially, the backward pass uses only
+        planned_duration rather than the stretched edge weights, so waiting time introduced by an
+        earliest_starttime constraint on a successor is correctly counted as slack for the
+        predecessor rather than being consumed by the edge weight.
+
+        Raises ValueError for unknown task IDs and for the internal artificial start/end nodes,
+        which are not part of the public API.
+        """
+        if task_id not in self._graph.nodes or task_id in _ARTIFICIAL_NODE_IDS:
+            raise ValueError(f"Task with id {task_id!r} is not a real task in this graph")
+        ls_minutes = self._compute_ls_minutes()
+        es_minutes = (
+            self.calculate_planned_starting_time_of_task(task_id) - self._starting_time_of_run
+        ).total_seconds() / 60
+        return timedelta(minutes=ls_minutes[task_id] - es_minutes)
+
     def calculate_planned_finish_time_of_graph(self) -> AwareDatetime:
         """
         Returns the planned finish time of the entire graph — the moment the last task completes.
@@ -710,10 +759,11 @@ class TaskDependencyGraph:
         critical_path_ids = self.get_critical_path_task_ids(include_artificial_nodes=include_artificial_nodes)
         critical_path_set = set(critical_path_ids)
 
-        # Pre-compute all start times once to avoid repeated DAG traversals inside sort keys.
+        # Pre-compute all start times and latest-start times once to avoid repeated DAG traversals.
         start_cache: dict[TaskId, AwareDatetime] = {
             tid: self.calculate_planned_starting_time_of_task(tid) for tid in self._graph.nodes
         }
+        ls_minutes_cache: dict[TaskId, float] = self._compute_ls_minutes()
 
         def _task_sort_key(tid: TaskId) -> tuple[AwareDatetime, str, str]:
             task: TaskNode = self._graph.nodes[tid]["domain_model"]
@@ -730,6 +780,8 @@ class TaskDependencyGraph:
                 if task_id not in _ARTIFICIAL_NODE_IDS
                 else planned_start + task.planned_duration
             )
+            es_minutes = (planned_start - self._starting_time_of_run).total_seconds() / 60
+            total_slack = timedelta(minutes=ls_minutes_cache[task_id] - es_minutes)
 
             predecessor_ids = sorted(
                 [
@@ -760,6 +812,7 @@ class TaskDependencyGraph:
                     planned_duration=task.planned_duration,
                     is_milestone=task.is_milestone,
                     is_on_critical_path=task_id in critical_path_set,
+                    total_slack=total_slack,
                     predecessor_task_ids=predecessor_ids,
                     successor_task_ids=successor_ids,
                 )

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -1173,3 +1173,123 @@ class TestValidateDefinition:
         assert result.is_valid is False
         dup_findings = [f for f in result.findings if f.code == ValidationCode.DUPLICATE_EXTERNAL_ID]
         assert len(dup_findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #88 – total slack per task
+# ---------------------------------------------------------------------------
+
+
+class TestTotalSlack:
+    """Tests for calculate_total_slack_of_task (issue #88)."""
+
+    def test_linear_graph_all_tasks_have_zero_slack(self) -> None:
+        """In a linear chain every task is on the critical path and has zero slack."""
+        a = _node("A", 10)
+        b = _node("B", 20)
+        c = _node("C", 5)
+        tdg = TaskDependencyGraph(
+            task_list=[a, b, c],
+            dependency_list=[_edge(a, b), _edge(b, c)],
+            starting_time_of_run=_T0,
+        )
+        assert tdg.calculate_total_slack_of_task(a.id) == timedelta(0)
+        assert tdg.calculate_total_slack_of_task(b.id) == timedelta(0)
+        assert tdg.calculate_total_slack_of_task(c.id) == timedelta(0)
+
+    def test_parallel_paths_shorter_has_positive_slack(self) -> None:
+        """The task on the shorter parallel path has positive total slack."""
+        short = _node("short", 5)
+        long_ = _node("long", 30)
+        end = _node("end", 5)
+        tdg = TaskDependencyGraph(
+            task_list=[short, long_, end],
+            dependency_list=[_edge(short, end), _edge(long_, end)],
+            starting_time_of_run=_T0,
+        )
+        # critical path: long (30) + end (5) = 35 min total
+        # short finishes at T0+5, end's LS = 30, so short has slack = 30 - 5 = 25 min
+        assert tdg.calculate_total_slack_of_task(long_.id) == timedelta(0)
+        assert tdg.calculate_total_slack_of_task(end.id) == timedelta(0)
+        assert tdg.calculate_total_slack_of_task(short.id) == timedelta(minutes=25)
+
+    def test_equal_length_parallel_paths_both_have_zero_slack(self) -> None:
+        """Two independent tasks of equal duration both lie on a longest path and have zero slack."""
+        a = _node("A", 10)
+        b = _node("B", 10)
+        tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[], starting_time_of_run=_T0)
+        assert tdg.calculate_total_slack_of_task(a.id) == timedelta(0)
+        assert tdg.calculate_total_slack_of_task(b.id) == timedelta(0)
+
+    def test_milestone_on_critical_path_has_zero_slack(self) -> None:
+        """A zero-duration milestone on the critical path has zero total slack."""
+        a = _node("A", 20)
+        ms = _node("MS", 0, milestone=True)
+        b = _node("B", 10)
+        tdg = TaskDependencyGraph(
+            task_list=[a, ms, b],
+            dependency_list=[_edge(a, ms), _edge(ms, b)],
+            starting_time_of_run=_T0,
+        )
+        assert tdg.calculate_total_slack_of_task(ms.id) == timedelta(0)
+
+    def test_milestone_off_critical_path_has_positive_slack(self) -> None:
+        """A zero-duration milestone on the shorter parallel path has positive total slack."""
+        long_ = _node("long", 30)
+        ms = _node("MS", 0, milestone=True)
+        short = _node("short", 5)
+        # ms → short is the short path; long is independent; graph finish = 30 min
+        tdg = TaskDependencyGraph(
+            task_list=[long_, ms, short],
+            dependency_list=[_edge(ms, short)],
+            starting_time_of_run=_T0,
+        )
+        # short LS = 30 - 5 = 25; ms LF = LS(short) = 25; ms LS = 25 - 0 = 25
+        assert tdg.calculate_total_slack_of_task(ms.id) == timedelta(minutes=25)
+        assert tdg.calculate_total_slack_of_task(short.id) == timedelta(minutes=25)
+
+    def test_earliest_starttime_wait_gives_slack_to_predecessor(self) -> None:
+        """When a successor has earliest_starttime, its predecessor gains slack from the wait."""
+        early = datetime(2024, 6, 1, 9, 0, 0, tzinfo=timezone.utc)  # T0 + 60 min
+        a = _node("A", 10)
+        b = _node("B", 20, earliest_start=early)
+        tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[_edge(a, b)], starting_time_of_run=_T0)
+        # A finishes at T0+10, B waits until T0+60, finishes at T0+80
+        # LS(B) = 80 - 20 = 60 → LF(A) = 60 → LS(A) = 60 - 10 = 50
+        assert tdg.calculate_total_slack_of_task(a.id) == timedelta(minutes=50)
+        assert tdg.calculate_total_slack_of_task(b.id) == timedelta(0)
+
+    def test_unknown_task_id_raises_value_error(self) -> None:
+        """An unrecognised task ID raises ValueError."""
+        task = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[task], dependency_list=[], starting_time_of_run=_T0)
+        with pytest.raises(ValueError):
+            tdg.calculate_total_slack_of_task(TaskId(uuid.uuid4()))
+
+    def test_artificial_node_id_raises_value_error(self) -> None:
+        """Artificial node IDs are not part of the public API and raise ValueError."""
+        task = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[task], dependency_list=[], starting_time_of_run=_T0)
+        with pytest.raises(ValueError):
+            tdg.calculate_total_slack_of_task(task_node_as_artificial_endnode.id)
+        with pytest.raises(ValueError):
+            tdg.calculate_total_slack_of_task(task_node_as_artificial_startnode.id)
+
+
+class TestScheduleEntryTotalSlack:
+    """Tests that total_slack is correctly included in ScheduleReport entries (issue #88)."""
+
+    def test_entry_total_slack_matches_calculate_total_slack(self) -> None:
+        """Each ScheduleEntry.total_slack matches calculate_total_slack_of_task."""
+        short = _node("short", 5)
+        long_ = _node("long", 30)
+        end = _node("end", 5)
+        tdg = TaskDependencyGraph(
+            task_list=[short, long_, end],
+            dependency_list=[_edge(short, end), _edge(long_, end)],
+            starting_time_of_run=_T0,
+        )
+        report = tdg.create_schedule_report()
+        by_id = {e.task_id: e for e in report.entries}
+        for task in [short, long_, end]:
+            assert by_id[task.id].total_slack == tdg.calculate_total_slack_of_task(task.id)

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -1214,12 +1214,20 @@ class TestTotalSlack:
         assert tdg.calculate_total_slack_of_task(short.id) == timedelta(minutes=25)
 
     def test_equal_length_parallel_paths_both_have_zero_slack(self) -> None:
-        """Two independent tasks of equal duration both lie on a longest path and have zero slack."""
+        """Two independent tasks of equal duration both lie on a longest path and have zero slack.
+
+        Note: NetworkX's dag_longest_path picks only one path when lengths are tied (insertion
+        order wins), so is_on_critical_path may return False for task B even though its total
+        slack is zero. This test documents that deliberate behaviour: zero slack and
+        is_on_critical_path are not equivalent when paths are tied.
+        """
         a = _node("A", 10)
         b = _node("B", 10)
         tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[], starting_time_of_run=_T0)
         assert tdg.calculate_total_slack_of_task(a.id) == timedelta(0)
         assert tdg.calculate_total_slack_of_task(b.id) == timedelta(0)
+        # Confirm the deliberate divergence: B has zero slack but is not on the NetworkX critical path
+        assert tdg.is_on_critical_path(b.id) is False
 
     def test_milestone_on_critical_path_has_zero_slack(self) -> None:
         """A zero-duration milestone on the critical path has zero total slack."""


### PR DESCRIPTION
## Summary
- Adds `calculate_total_slack_of_task(task_id: TaskId) -> timedelta` to `TaskDependencyGraph`
- Adds `total_slack: timedelta` field to `ScheduleEntry` (included in `create_schedule_report`)
- Private `_compute_ls_minutes()` helper performs the backward DAG pass once; `create_schedule_report` pre-caches it to avoid O(n) traversals

## Definition
Total slack = the maximum amount of time a task's planned start or finish can be delayed without pushing out the graph finish time. Zero means the task is on a critical path.

## Key design decision
The backward pass uses `planned_duration` directly, NOT the stretched edge weights from the forward pass. This ensures that waiting time introduced by an `earliest_starttime` constraint on a successor is counted as slack for the predecessor (see `test_earliest_starttime_wait_gives_slack_to_predecessor`).

## Test plan
- [ ] Linear graph: all tasks zero slack
- [ ] Parallel paths: shorter path has positive slack
- [ ] Equal-length parallel paths: both zero slack
- [ ] Milestone on critical path: zero slack
- [ ] Milestone off critical path: positive slack
- [ ] `earliest_starttime` wait: predecessor gains slack
- [ ] Unknown task ID raises `ValueError`
- [ ] Artificial node IDs raise `ValueError`
- [ ] `ScheduleEntry.total_slack` matches `calculate_total_slack_of_task`

🤖 Generated with [Claude Code](https://claude.com/claude-code)