### PR TITLE
feat: add MermaidGanttConfig for configurable Mermaid Gantt output (issue #89)

### DIFF
--- a/src/taskdependencygraph/models/__init__.py
+++ b/src/taskdependencygraph/models/__init__.py
@@ -1,12 +1,12 @@
 """models are python objects which we use to model tasks, dependencies and the graph they form"""
 
-from .mermaid_gantt_config import MermaidGanttConfig
 from .graph_definition_validation import (
     GraphDefinitionValidationFinding,
     GraphDefinitionValidationResult,
     ValidationCode,
 )
 from .ids import PersonId, RunGroupId, RunGroupPersonRelationId, RunId, TaskDependencyId, TaskId
+from .mermaid_gantt_config import MermaidGanttConfig
 from .person import Person
 from .schedule_report import ScheduleEntry, ScheduleReport
 from .task_dependency_edge import TaskDependencyEdge

--- a/src/taskdependencygraph/models/__init__.py
+++ b/src/taskdependencygraph/models/__init__.py
@@ -1,5 +1,6 @@
 """models are python objects which we use to model tasks, dependencies and the graph they form"""
 
+from .mermaid_gantt_config import MermaidGanttConfig
 from .graph_definition_validation import (
     GraphDefinitionValidationFinding,
     GraphDefinitionValidationResult,
@@ -15,6 +16,7 @@ from .task_node_as_artificial_endnode import ID_OF_ARTIFICIAL_ENDNODE
 from .task_node_as_artificial_startnode import ID_OF_ARTIFICIAL_STARTNODE
 
 __all__ = [
+    "MermaidGanttConfig",
     "GraphDefinitionValidationFinding",
     "GraphDefinitionValidationResult",
     "ValidationCode",

--- a/src/taskdependencygraph/models/mermaid_gantt_config.py
+++ b/src/taskdependencygraph/models/mermaid_gantt_config.py
@@ -1,0 +1,59 @@
+"""Configuration model for Mermaid Gantt chart output."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MermaidGanttConfig(BaseModel):
+    """Configuration for TaskDependencyGraph.to_mermaid_gantt() output.
+
+    All fields default to the values that were previously hardcoded, so calling
+    to_mermaid_gantt() without a config preserves the existing output exactly.
+
+    Configuration for other diagram formats (e.g. DOT/GraphViz) belongs in a
+    separate dedicated config class and must not be added here.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    title: str = Field(
+        default="A Gantt Diagram",
+        description="Chart title, emitted as 'title <value>' in the Mermaid header.",
+    )
+    date_format: str = Field(
+        default="YYYY-MM-DDTHH:mm:SZ",
+        description=(
+            "Mermaid dateFormat string controlling how task start dates are parsed. "
+            "See https://mermaid.js.org/syntax/gantt.html#setting-dates"
+        ),
+    )
+    axis_format: str = Field(
+        default="%d.%m %H:%M",
+        description="strftime-style format for x-axis tick labels, emitted as 'axisFormat <value>'.",
+    )
+    tick_interval: str = Field(
+        default="15minute",
+        description=(
+            "Interval between axis ticks, e.g. '1hour', '30minute'. "
+            "Emitted as 'tickInterval <value>'. "
+            "See https://mermaid.js.org/syntax/gantt.html#setting-an-axis-tick-interval"
+        ),
+    )
+    section_label: str = Field(
+        default="Example Stream",
+        description=(
+            "Section header for ungrouped output. When group_by_phase=True, tasks whose "
+            "phase field is None are placed under this section."
+        ),
+    )
+    group_by_phase: bool = Field(
+        default=False,
+        description=(
+            "When True, tasks are grouped into Mermaid sections by their phase field. "
+            "Tasks with phase=None are placed under section_label. "
+            "Phase groups appear in the order their phase is first encountered "
+            "during graph iteration."
+        ),
+    )
+
+
+__all__ = ["MermaidGanttConfig"]

--- a/src/taskdependencygraph/models/mermaid_gantt_config.py
+++ b/src/taskdependencygraph/models/mermaid_gantt_config.py
@@ -17,10 +17,12 @@ class MermaidGanttConfig(BaseModel):
 
     title: str = Field(
         default="A Gantt Diagram",
+        min_length=1,
         description="Chart title, emitted as 'title <value>' in the Mermaid header.",
     )
     date_format: str = Field(
         default="YYYY-MM-DDTHH:mm:SZ",
+        min_length=1,
         description=(
             "Mermaid dateFormat string controlling how task start dates are parsed. "
             "See https://mermaid.js.org/syntax/gantt.html#setting-dates"
@@ -28,18 +30,23 @@ class MermaidGanttConfig(BaseModel):
     )
     axis_format: str = Field(
         default="%d.%m %H:%M",
+        min_length=1,
         description="strftime-style format for x-axis tick labels, emitted as 'axisFormat <value>'.",
     )
     tick_interval: str = Field(
         default="15minute",
+        pattern=r"^\d+(millisecond|second|minute|hour|day|week|month)s?$",
         description=(
-            "Interval between axis ticks, e.g. '1hour', '30minute'. "
+            "Interval between axis ticks, e.g. '1hour', '30minutes'. "
+            "Must be a positive integer followed by a Mermaid time unit "
+            "(millisecond, second, minute, hour, day, week, month) with optional trailing 's'. "
             "Emitted as 'tickInterval <value>'. "
             "See https://mermaid.js.org/syntax/gantt.html#setting-an-axis-tick-interval"
         ),
     )
     section_label: str = Field(
         default="Example Stream",
+        min_length=1,
         description=(
             "Section header for ungrouped output. When group_by_phase=True, tasks whose "
             "phase field is None are placed under this section."

--- a/src/taskdependencygraph/models/mermaid_gantt_config.py
+++ b/src/taskdependencygraph/models/mermaid_gantt_config.py
@@ -49,7 +49,8 @@ class MermaidGanttConfig(BaseModel):
         default=False,
         description=(
             "When True, tasks are grouped into Mermaid sections by their phase field. "
-            "Tasks with phase=None are placed under section_label. "
+            "Tasks with phase=None (including the internal artificial start/end nodes) "
+            "are placed under section_label. "
             "Phase groups appear in the order their phase is first encountered "
             "during graph iteration."
         ),

--- a/src/taskdependencygraph/plotting/protocols.py
+++ b/src/taskdependencygraph/plotting/protocols.py
@@ -4,6 +4,8 @@ interface like descriptions for any kind of plotting "client" library
 
 from typing import Literal, Protocol
 
+from taskdependencygraph.models.mermaid_gantt_config import MermaidGanttConfig
+
 PlotMode = Literal["dot", "gantt"]
 
 
@@ -23,7 +25,7 @@ class MermaidPlottable(Protocol):
     something that can be plotted using Mermaid
     """
 
-    def to_mermaid_gantt(self) -> str:
+    def to_mermaid_gantt(self, config: MermaidGanttConfig | None = None) -> str:
         """
         returns the mermaid-gantt chart representation of this object as plain string
         """

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -19,8 +19,8 @@ from taskdependencygraph.models.graph_definition_validation import (
     GraphDefinitionValidationResult,
     ValidationCode,
 )
-from taskdependencygraph.models.mermaid_gantt_config import MermaidGanttConfig
 from taskdependencygraph.models.ids import TaskDependencyId, TaskId
+from taskdependencygraph.models.mermaid_gantt_config import MermaidGanttConfig
 from taskdependencygraph.models.schedule_report import ScheduleEntry, ScheduleReport
 from taskdependencygraph.models.task_dependency_edge import TaskDependencyEdge
 from taskdependencygraph.models.task_dependency_update import (

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -19,6 +19,7 @@ from taskdependencygraph.models.graph_definition_validation import (
     GraphDefinitionValidationResult,
     ValidationCode,
 )
+from taskdependencygraph.models.mermaid_gantt_config import MermaidGanttConfig
 from taskdependencygraph.models.ids import TaskDependencyId, TaskId
 from taskdependencygraph.models.schedule_report import ScheduleEntry, ScheduleReport
 from taskdependencygraph.models.task_dependency_edge import TaskDependencyEdge
@@ -946,17 +947,42 @@ class TaskDependencyGraph:
         # https://kroki.io/#try (select 'GraphViz' in the dropdown)
         return result
 
-    def to_mermaid_gantt(self) -> str:
+    def to_mermaid_gantt(self, config: MermaidGanttConfig | None = None) -> str:
         """
-        Returns the mermaid-gantt-representation of the entire tdg
+        Returns the Mermaid Gantt chart representation of the entire graph.
+
+        Pass a MermaidGanttConfig to customise the title, date/axis/tick formats,
+        section label, or phase grouping. Calling with no argument (or None) preserves
+        the existing default output exactly.
         """
-        result: str = """gantt
-    title A Gantt Diagram
-    dateFormat YYYY-MM-DDTHH:mm:SZ
-    axisFormat %d.%m %H:%M
-    tickInterval 15minute
-    section Example Stream
-"""
-        # todo: group by stream https://github.com/Hochfrequenz/cutover-tool/issues/374
-        result += "".join(self._get_task_mermaid_gantt(tid) for tid in self._graph.nodes().keys())
-        return result
+        if config is None:
+            config = MermaidGanttConfig()
+
+        header = (
+            f"gantt\n"
+            f"    title {config.title}\n"
+            f"    dateFormat {config.date_format}\n"
+            f"    axisFormat {config.axis_format}\n"
+            f"    tickInterval {config.tick_interval}\n"
+        )
+
+        if not config.group_by_phase:
+            body = f"    section {config.section_label}\n"
+            body += "".join(self._get_task_mermaid_gantt(tid) for tid in self._graph.nodes().keys())
+            return header + body
+
+        # Group tasks by phase, preserving graph iteration order within each group.
+        phases: dict[str | None, list[TaskId]] = {}
+        for tid in self._graph.nodes():
+            phase = self._graph.nodes[tid]["domain_model"].phase
+            if phase not in phases:
+                phases[phase] = []
+            phases[phase].append(tid)
+
+        body = ""
+        for phase, tids in phases.items():
+            section_name = config.section_label if phase is None else phase
+            body += f"    section {section_name}\n"
+            body += "".join(self._get_task_mermaid_gantt(tid) for tid in tids)
+
+        return header + body

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -1453,6 +1453,13 @@ class TestMermaidGanttConfig:
             assert f"title {cfg.title}" in output
             assert f"tickInterval {cfg.tick_interval}" in output
 
+
+# ---------------------------------------------------------------------------
+
+
+class TestMermaidGanttConfigValidation:
+    """Tests for MermaidGanttConfig field validation (construction-time enforcement)."""
+
     def test_empty_title_raises_validation_error(self) -> None:
         """An empty title string is rejected at construction time."""
         with pytest.raises(ValidationError):

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 import networkx as nx  # type: ignore[import-untyped]
 import pytest
-from pydantic import AwareDatetime
+from pydantic import AwareDatetime, ValidationError
 
 from taskdependencygraph.models.graph_definition_validation import (
     ValidationCode,
@@ -1436,3 +1436,63 @@ class TestMermaidGanttConfig:
         alpha_pos = output.index("section Alpha")
         beta_pos = output.index("section Beta")
         assert alpha_pos < beta_pos
+
+    def test_multiple_configs_each_produce_valid_charts(self) -> None:
+        """Creating several config instances and generating charts from each all succeed."""
+        a = _node("A", 10)
+        b = _node("B", 20)
+        tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[_edge(a, b)], starting_time_of_run=_T0)
+        configs = [
+            MermaidGanttConfig(),
+            MermaidGanttConfig(title="Project X", tick_interval="1hour"),
+            MermaidGanttConfig(axis_format="%H:%M", section_label="Stream A", group_by_phase=False),
+        ]
+        for cfg in configs:
+            output = tdg.to_mermaid_gantt(cfg)
+            assert output.startswith("gantt\n")
+            assert f"title {cfg.title}" in output
+            assert f"tickInterval {cfg.tick_interval}" in output
+
+    def test_empty_title_raises_validation_error(self) -> None:
+        """An empty title string is rejected at construction time."""
+        with pytest.raises(ValidationError):
+            MermaidGanttConfig(title="")
+
+    def test_empty_date_format_raises_validation_error(self) -> None:
+        """An empty date_format string is rejected at construction time."""
+        with pytest.raises(ValidationError):
+            MermaidGanttConfig(date_format="")
+
+    def test_empty_axis_format_raises_validation_error(self) -> None:
+        """An empty axis_format string is rejected at construction time."""
+        with pytest.raises(ValidationError):
+            MermaidGanttConfig(axis_format="")
+
+    def test_empty_section_label_raises_validation_error(self) -> None:
+        """An empty section_label string is rejected at construction time."""
+        with pytest.raises(ValidationError):
+            MermaidGanttConfig(section_label="")
+
+    def test_invalid_tick_interval_raises_validation_error(self) -> None:
+        """A tick_interval that doesn't match the Mermaid pattern is rejected at construction time."""
+        with pytest.raises(ValidationError):
+            MermaidGanttConfig(tick_interval="notaninterval")
+
+    def test_tick_interval_missing_number_raises_validation_error(self) -> None:
+        """A tick_interval without a leading integer is rejected at construction time."""
+        with pytest.raises(ValidationError):
+            MermaidGanttConfig(tick_interval="hour")
+
+    def test_tick_interval_plural_unit_is_accepted(self) -> None:
+        """tick_interval values with plural units (e.g. '30minutes') are accepted."""
+        cfg = MermaidGanttConfig(tick_interval="30minutes")
+        assert cfg.tick_interval == "30minutes"
+
+    @pytest.mark.parametrize(
+        "interval",
+        ["1millisecond", "5seconds", "15minute", "1hour", "2hours", "1day", "1week", "1month"],
+    )
+    def test_valid_tick_intervals_are_accepted(self, interval: str) -> None:
+        """All supported Mermaid tick_interval unit variants are accepted."""
+        cfg = MermaidGanttConfig(tick_interval=interval)
+        assert cfg.tick_interval == interval

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -1391,6 +1391,22 @@ class TestMermaidGanttConfig:
         assert "section Phase 1" in output
         assert "section Phase 2" in output
 
+    def test_default_output_is_identical_to_hardcoded_baseline(self) -> None:
+        """Passing no config produces byte-for-byte identical output to the old hardcoded version."""
+        task = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[task], dependency_list=[], starting_time_of_run=_T0)
+        # Build the expected header the same way the old triple-quoted string did.
+        expected_header = (
+            "gantt\n"
+            "    title A Gantt Diagram\n"
+            "    dateFormat YYYY-MM-DDTHH:mm:SZ\n"
+            "    axisFormat %d.%m %H:%M\n"
+            "    tickInterval 15minute\n"
+            "    section Example Stream\n"
+        )
+        output = tdg.to_mermaid_gantt()
+        assert output.startswith(expected_header)
+
     def test_group_by_phase_none_tasks_go_under_section_label(self) -> None:
         """Tasks with phase=None are placed under section_label when group_by_phase=True."""
         a = _node("A", 10)  # phase=None
@@ -1399,3 +1415,24 @@ class TestMermaidGanttConfig:
         output = tdg.to_mermaid_gantt(MermaidGanttConfig(group_by_phase=True, section_label="Ungrouped"))
         assert "section Ungrouped" in output
         assert "section Phase 1" in output
+
+    def test_group_by_phase_all_none_phases_produces_single_section(self) -> None:
+        """When every task has phase=None, group_by_phase=True emits a single section."""
+        a = _node("A", 10)
+        b = _node("B", 20)
+        tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(group_by_phase=True, section_label="All"))
+        assert output.count("section ") == 1
+        assert "section All" in output
+
+    def test_group_by_phase_section_order_follows_first_encounter(self) -> None:
+        """Phase sections appear in the order their phase is first encountered in graph iteration."""
+        a = _node("A", 10, phase="Alpha")
+        b = _node("B", 20, phase="Beta")
+        c = _node("C", 5, phase="Alpha")
+        tdg = TaskDependencyGraph(task_list=[a, b, c], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(group_by_phase=True))
+        # Artificial nodes (phase=None) appear first, then Alpha, then Beta in insertion order.
+        alpha_pos = output.index("section Alpha")
+        beta_pos = output.index("section Beta")
+        assert alpha_pos < beta_pos

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -10,6 +10,7 @@ from taskdependencygraph.models.graph_definition_validation import (
     ValidationCode,
 )
 from taskdependencygraph.models.ids import TaskDependencyId, TaskId
+from taskdependencygraph.models.mermaid_gantt_config import MermaidGanttConfig
 from taskdependencygraph.models.task_dependency_edge import TaskDependencyEdge
 from taskdependencygraph.models.task_node import TaskNode
 from taskdependencygraph.models.task_node_as_artificial_endnode import (
@@ -653,7 +654,12 @@ _T0 = datetime(2024, 6, 1, 8, 0, 0, tzinfo=timezone.utc)
 
 
 def _node(
-    external_id: str, duration_minutes: int, *, milestone: bool = False, earliest_start: datetime | None = None
+    external_id: str,
+    duration_minutes: int,
+    *,
+    milestone: bool = False,
+    earliest_start: datetime | None = None,
+    phase: str | None = None,
 ) -> TaskNode:
     return TaskNode(
         id=TaskId(uuid.uuid4()),
@@ -662,6 +668,7 @@ def _node(
         planned_duration=timedelta(minutes=duration_minutes),
         is_milestone=milestone,
         earliest_starttime=earliest_start,
+        phase=phase,
     )
 
 
@@ -1301,3 +1308,94 @@ class TestScheduleEntryTotalSlack:
         by_id = {e.task_id: e for e in report.entries}
         for task in [short, long_, end]:
             assert by_id[task.id].total_slack == tdg.calculate_total_slack_of_task(task.id)
+
+
+# ---------------------------------------------------------------------------
+# Issue #89 – configurable Mermaid Gantt output
+# ---------------------------------------------------------------------------
+
+
+class TestMermaidGanttConfig:
+    """Tests for to_mermaid_gantt with MermaidGanttConfig (issue #89)."""
+
+    def test_default_output_contains_hardcoded_defaults(self) -> None:
+        """Calling with no config preserves the existing title/format/section defaults."""
+        task = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[task], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt()
+        assert "title A Gantt Diagram" in output
+        assert "dateFormat YYYY-MM-DDTHH:mm:SZ" in output
+        assert "axisFormat %d.%m %H:%M" in output
+        assert "tickInterval 15minute" in output
+        assert "section Example Stream" in output
+
+    def test_custom_title_appears_in_output(self) -> None:
+        """A custom title is rendered in the chart header."""
+        task = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[task], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(title="My Project"))
+        assert "title My Project" in output
+        assert "title A Gantt Diagram" not in output
+
+    def test_custom_date_format_appears_in_output(self) -> None:
+        """A custom date_format is emitted in the chart header."""
+        task = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[task], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(date_format="YYYY-MM-DD"))
+        assert "dateFormat YYYY-MM-DD" in output
+
+    def test_custom_axis_format_appears_in_output(self) -> None:
+        """A custom axis_format is emitted in the chart header."""
+        task = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[task], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(axis_format="%H:%M"))
+        assert "axisFormat %H:%M" in output
+
+    def test_custom_tick_interval_appears_in_output(self) -> None:
+        """A custom tick_interval is emitted in the chart header."""
+        task = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[task], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(tick_interval="1hour"))
+        assert "tickInterval 1hour" in output
+
+    def test_custom_section_label_appears_in_output(self) -> None:
+        """A custom section_label replaces the default section header."""
+        task = _node("A", 10)
+        tdg = TaskDependencyGraph(task_list=[task], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(section_label="My Stream"))
+        assert "section My Stream" in output
+        assert "section Example Stream" not in output
+
+    def test_critical_path_task_still_marked_crit(self) -> None:
+        """Critical-path tasks are still marked with 'crit' when using a custom config."""
+        a = _node("A", 10)
+        b = _node("B", 20)
+        tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[_edge(a, b)], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(title="Custom"))
+        assert "crit" in output
+
+    def test_milestone_still_marked_milestone(self) -> None:
+        """Milestones are still marked with 'milestone' when using a custom config."""
+        ms = _node("MS", 0, milestone=True)
+        tdg = TaskDependencyGraph(task_list=[ms], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(title="Custom"))
+        assert "milestone" in output
+
+    def test_group_by_phase_creates_sections_per_phase(self) -> None:
+        """When group_by_phase=True, tasks are grouped into Mermaid sections by phase."""
+        a = _node("A", 10, phase="Phase 1")
+        b = _node("B", 20, phase="Phase 2")
+        c = _node("C", 5, phase="Phase 1")
+        tdg = TaskDependencyGraph(task_list=[a, b, c], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(group_by_phase=True))
+        assert "section Phase 1" in output
+        assert "section Phase 2" in output
+
+    def test_group_by_phase_none_tasks_go_under_section_label(self) -> None:
+        """Tasks with phase=None are placed under section_label when group_by_phase=True."""
+        a = _node("A", 10)  # phase=None
+        b = _node("B", 20, phase="Phase 1")
+        tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[], starting_time_of_run=_T0)
+        output = tdg.to_mermaid_gantt(MermaidGanttConfig(group_by_phase=True, section_label="Ungrouped"))
+        assert "section Ungrouped" in output
+        assert "section Phase 1" in output


### PR DESCRIPTION
## Summary
- Adds `MermaidGanttConfig` (frozen Pydantic model) with fields: `title`, `date_format`, `axis_format`, `tick_interval`, `section_label`, `group_by_phase`
- Updates `to_mermaid_gantt(config: MermaidGanttConfig | None = None)` — default output is byte-for-byte identical to the previous hardcoded version
- Adds `group_by_phase: bool = False` — when True, tasks are grouped into Mermaid sections by their `phase` field; tasks with `phase=None` go under `section_label`
- Updates `MermaidPlottable` protocol to reflect the optional `config` parameter (existing callers unaffected)
- Exports `MermaidGanttConfig` from `taskdependencygraph.models`

## Test plan
- [ ] Default output retains hardcoded title/date/axis/tick/section defaults
- [ ] Custom title appears in output
- [ ] Custom date_format, axis_format, tick_interval appear in output
- [ ] Custom section_label replaces default section header
- [ ] `crit` marker still emitted for critical-path tasks
- [ ] `milestone` marker still emitted for milestone tasks
- [ ] `group_by_phase=True` creates one section per phase
- [ ] Tasks with `phase=None` go under `section_label` when grouping
- [ ] Kroki SVG test (Docker-gated) continues to call `to_mermaid_gantt()` without args

🤖 Generated with [Claude Code](https://claude.com/claude-code)