### PR TITLE
test: add missing tests for preview APIs and to_dot; fix extract_sub_graph error message

### DIFF
--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -860,7 +860,7 @@ class TaskDependencyGraph:
         if not self._graph.nodes[sub_start]["domain_model"].is_milestone:
             raise ValueError(f"Node with id {sub_start} (start) is not a milestone")
         if not self._graph.nodes[sub_end]["domain_model"].is_milestone:
-            raise ValueError(f"Node with id {sub_end} end is not a milestone")
+            raise ValueError(f"Node with id {sub_end} (end) is not a milestone")
         if not nx.has_path(self._graph, sub_start, sub_end):
             raise ValueError(f"There is no path between {sub_start} and {sub_end}")
 

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -939,8 +939,8 @@ class TaskDependencyGraph:
         result: str = "digraph fahrplan{\nrankdir = LR;\nnode [shape=record fontname=Calibri];\n"
         result += "".join(self._get_task_dot(tid) for tid in self._graph.nodes().keys())
         result += "".join(
-            self._graph[successor][predecessor]["domain_model"].to_dot()
-            for successor, predecessor in self._graph.edges()
+            self._graph[predecessor][successor]["domain_model"].to_dot()
+            for predecessor, successor in self._graph.edges()
         )
         result += "}"
         # for debugging purposes you might copy the result from your IDE/Debugger and paste it here:

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -1686,3 +1686,57 @@ class TestPublicApiImports:
         """AddNodeToGraphPreviewResponse and AddEdgeToGraphPreviewResponse are importable from top-level."""
         assert tdg_pkg.AddNodeToGraphPreviewResponse is AddNodeToGraphPreviewResponse
         assert tdg_pkg.AddEdgeToGraphPreviewResponse is AddEdgeToGraphPreviewResponse
+
+
+class TestExtractSubgraphErrorMessages:
+    """Error message formatting for extract_sub_graph — both start and end node errors use (parentheses)."""
+
+    def test_end_not_milestone_error_message_contains_parentheses(self) -> None:
+        full_graph = copy.deepcopy(graph_ferdinand_with_milestones)
+        # task_S_milestone is a valid milestone start; task_T is not a milestone
+        with pytest.raises(ValueError) as raised:
+            _ = full_graph.extract_sub_graph(task_S_milestone.id, task_T.id)
+        assert "(end) is not a milestone" in str(raised.value)
+
+    def test_start_not_milestone_error_message_contains_parentheses(self) -> None:
+        full_graph = copy.deepcopy(graph_ferdinand_with_milestones)
+        # task_T is not a milestone
+        with pytest.raises(ValueError) as raised:
+            _ = full_graph.extract_sub_graph(task_T.id, task_W_milestone.id)
+        assert "(start) is not a milestone" in str(raised.value)
+
+
+class TestToDot:
+    """Direct unit tests for TaskDependencyGraph.to_dot() — verifies structure and edge direction."""
+
+    def test_output_starts_with_digraph(self) -> None:
+        graph = copy.deepcopy(graph_ferdinand_with_milestones)
+        dot = graph.to_dot()
+        assert dot.startswith("digraph fahrplan{")
+
+    def test_output_ends_with_closing_brace(self) -> None:
+        graph = copy.deepcopy(graph_ferdinand_with_milestones)
+        dot = graph.to_dot()
+        assert dot.strip().endswith("}")
+
+    def test_output_contains_node_entries(self) -> None:
+        graph = copy.deepcopy(graph_ferdinand_with_milestones)
+        dot = graph.to_dot()
+        assert f'"svg-{task_S_milestone.id}"' in dot or str(task_S_milestone.id) in dot
+
+    def test_output_contains_edges_in_correct_direction(self) -> None:
+        tdg = TaskDependencyGraph(
+            task_list=[task_M, task_N],
+            dependency_list=[
+                TaskDependencyEdge(
+                    id=TaskDependencyId(uuid.uuid4()),
+                    task_predecessor=task_M.id,
+                    task_successor=task_N.id,
+                )
+            ],
+            starting_time_of_run=datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        dot = tdg.to_dot()
+        # edge must be rendered predecessor → successor, not the other way around
+        assert f'"{task_M.id}" -> "{task_N.id}"' in dot
+        assert f'"{task_N.id}" -> "{task_M.id}"' not in dot

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -1697,6 +1697,7 @@ class TestExtractSubgraphErrorMessages:
         with pytest.raises(ValueError) as raised:
             _ = full_graph.extract_sub_graph(task_S_milestone.id, task_T.id)
         assert "(end) is not a milestone" in str(raised.value)
+        assert str(task_T.id) in str(raised.value)
 
     def test_start_not_milestone_error_message_contains_parentheses(self) -> None:
         full_graph = copy.deepcopy(graph_ferdinand_with_milestones)
@@ -1704,6 +1705,7 @@ class TestExtractSubgraphErrorMessages:
         with pytest.raises(ValueError) as raised:
             _ = full_graph.extract_sub_graph(task_T.id, task_W_milestone.id)
         assert "(start) is not a milestone" in str(raised.value)
+        assert str(task_T.id) in str(raised.value)
 
 
 class TestToDot:
@@ -1722,7 +1724,7 @@ class TestToDot:
     def test_output_contains_node_entries(self) -> None:
         graph = copy.deepcopy(graph_ferdinand_with_milestones)
         dot = graph.to_dot()
-        assert f'"svg-{task_S_milestone.id}"' in dot or str(task_S_milestone.id) in dot
+        assert f'id="svg-{task_S_milestone.id}"' in dot
 
     def test_output_contains_edges_in_correct_direction(self) -> None:
         tdg = TaskDependencyGraph(

--- a/unittests/test_tdg_add_nodes_and_edges.py
+++ b/unittests/test_tdg_add_nodes_and_edges.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 
 import pytest
 
+from taskdependencygraph.models import AddEdgeToGraphPreviewResponse, AddNodeToGraphPreviewResponse
 from taskdependencygraph.models.ids import TaskDependencyId, TaskId
 from taskdependencygraph.models.task_dependency_edge import TaskDependencyEdge
 from taskdependencygraph.models.task_node import TaskNode
@@ -16,7 +17,7 @@ from taskdependencygraph.models.task_node_as_artificial_endnode import ID_OF_ART
 from taskdependencygraph.models.task_node_as_artificial_startnode import ID_OF_ARTIFICIAL_STARTNODE
 from taskdependencygraph.task_dependency_graph import TaskDependencyGraph
 
-from .example_tdgs import graph_anna, task_A, task_C, task_D
+from .example_tdgs import graph_anna, task_A, task_B, task_C, task_D
 
 
 @pytest.mark.parametrize(
@@ -81,3 +82,109 @@ def test_adding_a_cycle_fails() -> None:
         graph.add_edge(new_edge_which_causes_a_cycle)
     assert "cycle" in str(value_error_info.value)
     assert not graph._graph.has_edge(task_D.id, task_A.id)
+
+
+class TestCanTaskBeAdded:
+    """Direct tests of the can_task_be_added preview API — verifies the response object, not just exceptions."""
+
+    def test_returns_true_for_valid_task(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        new_task = TaskNode(id=TaskId(uuid.uuid4()), external_id="Z", name="Z", planned_duration=timedelta(minutes=1))
+        result = graph.can_task_be_added(new_task)
+        assert isinstance(result, AddNodeToGraphPreviewResponse)
+        assert result.can_be_added is True
+        assert result.error_message is None
+
+    def test_returns_false_for_duplicate_task_id(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        duplicate = TaskNode(id=task_A.id, external_id="Z", name="Z", planned_duration=timedelta(minutes=1))
+        result = graph.can_task_be_added(duplicate)
+        assert result.can_be_added is False
+        assert result.error_message is not None
+        assert str(task_A.id) in result.error_message
+
+    def test_returns_false_for_duplicate_external_id(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        duplicate = TaskNode(
+            id=TaskId(uuid.uuid4()), external_id=task_A.external_id, name="Z", planned_duration=timedelta(minutes=1)
+        )
+        result = graph.can_task_be_added(duplicate)
+        assert result.can_be_added is False
+        assert result.error_message is not None
+        assert str(task_A.external_id) in result.error_message
+
+
+class TestCanEdgeBeAdded:
+    """Direct tests of the can_edge_be_added preview API — verifies all error branches and the success path."""
+
+    def test_returns_true_for_valid_edge(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        # graph_anna has A→B, A→C, B→D; no C→D edge exists
+        new_edge = TaskDependencyEdge(
+            id=TaskDependencyId(uuid.uuid4()), task_predecessor=task_C.id, task_successor=task_D.id
+        )
+        result = graph.can_edge_be_added(new_edge)
+        assert isinstance(result, AddEdgeToGraphPreviewResponse)
+        assert result.can_be_added is True
+        assert result.error_message is None
+
+    def test_returns_false_when_successor_not_in_graph(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        missing_id = TaskId(uuid.uuid4())
+        edge = TaskDependencyEdge(
+            id=TaskDependencyId(uuid.uuid4()), task_predecessor=task_A.id, task_successor=missing_id
+        )
+        result = graph.can_edge_be_added(edge)
+        assert result.can_be_added is False
+        assert result.error_message is not None
+        assert "successor" in result.error_message
+
+    def test_returns_false_when_predecessor_not_in_graph(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        missing_id = TaskId(uuid.uuid4())
+        edge = TaskDependencyEdge(
+            id=TaskDependencyId(uuid.uuid4()), task_predecessor=missing_id, task_successor=task_A.id
+        )
+        result = graph.can_edge_be_added(edge)
+        assert result.can_be_added is False
+        assert result.error_message is not None
+        assert "predecessor" in result.error_message
+
+    def test_returns_false_for_duplicate_edge_id(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        existing_id = graph._graph.edges[task_A.id, task_B.id]["domain_model"].id
+        edge = TaskDependencyEdge(id=existing_id, task_predecessor=task_C.id, task_successor=task_D.id)
+        result = graph.can_edge_be_added(edge)
+        assert result.can_be_added is False
+        assert result.error_message is not None
+
+    def test_returns_false_for_duplicate_edge_pair(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        # A→B already exists; use a new ID to bypass the duplicate-ID check
+        duplicate = TaskDependencyEdge(
+            id=TaskDependencyId(uuid.uuid4()), task_predecessor=task_A.id, task_successor=task_B.id
+        )
+        result = graph.can_edge_be_added(duplicate)
+        assert result.can_be_added is False
+        assert result.error_message is not None
+
+    def test_returns_false_for_opposite_edge(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        # A→B exists; adding B→A is the "opposite" direction
+        opposite = TaskDependencyEdge(
+            id=TaskDependencyId(uuid.uuid4()), task_predecessor=task_B.id, task_successor=task_A.id
+        )
+        result = graph.can_edge_be_added(opposite)
+        assert result.can_be_added is False
+        assert result.error_message is not None
+
+    def test_returns_false_when_edge_would_create_cycle(self) -> None:
+        graph = copy.deepcopy(graph_anna)
+        # A→B→D exists; D→A would form a cycle
+        cycle_edge = TaskDependencyEdge(
+            id=TaskDependencyId(uuid.uuid4()), task_predecessor=task_D.id, task_successor=task_A.id
+        )
+        result = graph.can_edge_be_added(cycle_edge)
+        assert result.can_be_added is False
+        assert result.error_message is not None
+        assert "cycle" in result.error_message

--- a/unittests/test_tdg_add_nodes_and_edges.py
+++ b/unittests/test_tdg_add_nodes_and_edges.py
@@ -157,6 +157,7 @@ class TestCanEdgeBeAdded:
         result = graph.can_edge_be_added(edge)
         assert result.can_be_added is False
         assert result.error_message is not None
+        assert str(existing_id) in result.error_message
 
     def test_returns_false_for_duplicate_edge_pair(self) -> None:
         graph = copy.deepcopy(graph_anna)
@@ -167,6 +168,7 @@ class TestCanEdgeBeAdded:
         result = graph.can_edge_be_added(duplicate)
         assert result.can_be_added is False
         assert result.error_message is not None
+        assert str(task_A.id) in result.error_message
 
     def test_returns_false_for_opposite_edge(self) -> None:
         graph = copy.deepcopy(graph_anna)
@@ -177,6 +179,7 @@ class TestCanEdgeBeAdded:
         result = graph.can_edge_be_added(opposite)
         assert result.can_be_added is False
         assert result.error_message is not None
+        assert "Opposite" in result.error_message
 
     def test_returns_false_when_edge_would_create_cycle(self) -> None:
         graph = copy.deepcopy(graph_anna)


### PR DESCRIPTION
## Summary

- **Bug fix**: `extract_sub_graph()` had a missing `(` `)` around `end` in the error message on line 863 (`"Node with id X end is not a milestone"` → `"Node with id X (end) is not a milestone"`), inconsistent with the matching start-node error
- **New tests** for `can_task_be_added()` — directly verifying `AddNodeToGraphPreviewResponse` (all 3 branches: success, duplicate id, duplicate external_id)
- **New tests** for `can_edge_be_added()` — directly verifying `AddEdgeToGraphPreviewResponse` (all 7 branches: success, missing successor, missing predecessor, duplicate edge id, duplicate edge pair, opposite edge, would-create-cycle); several of these branches had no test at all before
- **New tests** for `TaskDependencyGraph.to_dot()` — verifies structure, node presence, and that edges render in the correct predecessor→successor direction
- **New tests** for `extract_sub_graph` error message formatting — pins both `(start)` and `(end)` parenthesis convention

## Test plan
- [ ] All 174 tests pass locally
- [ ] pylint 10.00/10 with the correct rcfiles
- [ ] isort + black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)