### PR TITLE
fix: replace deprecated Field(min=...) with Field(ge=...) for timedelta constraints (issue #110)

### DIFF
--- a/src/taskdependencygraph/models/task_node.py
+++ b/src/taskdependencygraph/models/task_node.py
@@ -67,7 +67,7 @@ class TaskNode(BaseModel):
     Tasks can have none, one or more tags. Tags are a possibility to group tasks.
     Example: ['IS-U', 'Rechnungen'].
     """
-    planned_duration: Annotated[timedelta, Field(min=timedelta(minutes=0))]
+    planned_duration: Annotated[timedelta, Field(ge=timedelta(0))]
     """ 
     The planned_duration_minutes expresses how long the task execution is planned to last (in minutes).
     Example: timedelta(minutes=600) (for 10h)
@@ -91,7 +91,7 @@ class TaskNode(BaseModel):
     The task may only start at this datetime or later, even if predecessors finish earlier.
     """
 
-    planned_duration_of_predecessor_tasks: Annotated[timedelta, Field(min=timedelta(minutes=0))] | None = None
+    planned_duration_of_predecessor_tasks: Annotated[timedelta, Field(ge=timedelta(0))] | None = None
     """
     The planned_duration_of_predecessor_tasks is the sum of the duration of the predecessor tasks. 
     The planned_duration_of_predecessor_tasks expresses, how long it takes from the beginning of the first task 

--- a/unittests/model_tests/test_task_node_duration_validation.py
+++ b/unittests/model_tests/test_task_node_duration_validation.py
@@ -15,7 +15,7 @@ from taskdependencygraph.models.ids import TaskId
 from taskdependencygraph.models.task_node import TaskNode
 
 
-def _make_task(**kwargs) -> TaskNode:
+def _make_task(**kwargs: Any) -> TaskNode:
     defaults: dict[str, Any] = {
         "id": TaskId(uuid.uuid4()),
         "external_id": "T1",

--- a/unittests/model_tests/test_task_node_duration_validation.py
+++ b/unittests/model_tests/test_task_node_duration_validation.py
@@ -60,6 +60,8 @@ class TestPlannedDurationOfPredecessorTasks:
 
 class TestNoDeprecationWarnings:
     def test_constructing_task_node_emits_no_pydantic_deprecation_warnings(self) -> None:
+        # Passes implicitly if no warning is raised; PydanticDeprecatedSince20 inherits
+        # from DeprecationWarning, which simplefilter("error") converts to an exception.
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             _make_task(planned_duration=timedelta(minutes=5))

--- a/unittests/model_tests/test_task_node_duration_validation.py
+++ b/unittests/model_tests/test_task_node_duration_validation.py
@@ -1,0 +1,65 @@
+"""
+Tests for TaskNode timedelta field validation — ensures constraints work correctly
+and that no PydanticDeprecatedSince20 warnings are emitted.
+"""
+
+import uuid
+import warnings
+from datetime import timedelta
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from taskdependencygraph.models.ids import TaskId
+from taskdependencygraph.models.task_node import TaskNode
+
+
+def _make_task(**kwargs) -> TaskNode:
+    defaults: dict[str, Any] = {
+        "id": TaskId(uuid.uuid4()),
+        "external_id": "T1",
+        "name": "Task",
+        "planned_duration": timedelta(minutes=5),
+    }
+    defaults.update(kwargs)
+    return TaskNode(**defaults)
+
+
+class TestPlannedDuration:
+    def test_accepts_zero_duration(self) -> None:
+        task = _make_task(planned_duration=timedelta(0))
+        assert task.planned_duration == timedelta(0)
+
+    def test_accepts_positive_duration(self) -> None:
+        task = _make_task(planned_duration=timedelta(hours=2))
+        assert task.planned_duration == timedelta(hours=2)
+
+    def test_rejects_negative_duration(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_task(planned_duration=timedelta(minutes=-1))
+
+
+class TestPlannedDurationOfPredecessorTasks:
+    def test_accepts_none(self) -> None:
+        task = _make_task(planned_duration_of_predecessor_tasks=None)
+        assert task.planned_duration_of_predecessor_tasks is None
+
+    def test_accepts_zero(self) -> None:
+        task = _make_task(planned_duration_of_predecessor_tasks=timedelta(0))
+        assert task.planned_duration_of_predecessor_tasks == timedelta(0)
+
+    def test_accepts_positive(self) -> None:
+        task = _make_task(planned_duration_of_predecessor_tasks=timedelta(minutes=30))
+        assert task.planned_duration_of_predecessor_tasks == timedelta(minutes=30)
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_task(planned_duration_of_predecessor_tasks=timedelta(seconds=-1))
+
+
+class TestNoDeprecationWarnings:
+    def test_constructing_task_node_emits_no_pydantic_deprecation_warnings(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _make_task(planned_duration=timedelta(minutes=5))


### PR DESCRIPTION
## Summary

- Fixes #110
- `Field(min=timedelta(...))` in Pydantic V2 emits `PydanticDeprecatedSince20` warnings **and silently ignores the constraint** — negative durations were accepted without any validation error
- Replaced with `Field(ge=timedelta(0))` on both `planned_duration` and `planned_duration_of_predecessor_tasks`, which correctly enforces the non-negative constraint and emits no warnings

## Test plan
- [ ] `TestPlannedDuration`: zero, positive accepted; negative rejected with `ValidationError`
- [ ] `TestPlannedDurationOfPredecessorTasks`: `None`, zero, positive accepted; negative rejected
- [ ] `TestNoDeprecationWarnings`: constructing `TaskNode` with `warnings.simplefilter("error")` does not raise
- [ ] Full suite passes with `PYTHONPATH=src`
- [ ] pylint 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)