### PR TITLE
feat: add free_slack to ScheduleEntry

### DIFF
--- a/src/taskdependencygraph/models/schedule_report.py
+++ b/src/taskdependencygraph/models/schedule_report.py
@@ -27,6 +27,8 @@ class ScheduleEntry(BaseModel):
     is_on_critical_path: bool
     total_slack: timedelta
     """Maximum delay the task can absorb without pushing out the graph finish time."""
+    free_slack: timedelta
+    """Maximum delay the task can absorb without delaying the earliest start of any direct successor."""
     predecessor_task_ids: list[TaskId]
     successor_task_ids: list[TaskId]
 

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -812,11 +812,7 @@ class TaskDependencyGraph:
                     is_on_critical_path=task_id in critical_path_set,
                     total_slack=latest_start_cache[task_id] - (planned_start - self._starting_time_of_run),
                     free_slack=min(
-                        (
-                            start_cache[s]
-                            for s in self._graph.successors(task_id)
-                            if s not in _ARTIFICIAL_NODE_IDS
-                        ),
+                        (start_cache[s] for s in self._graph.successors(task_id) if s not in _ARTIFICIAL_NODE_IDS),
                         default=start_cache[task_node_as_artificial_endnode.id],
                     )
                     - planned_finish,

--- a/src/taskdependencygraph/task_dependency_graph.py
+++ b/src/taskdependencygraph/task_dependency_graph.py
@@ -811,6 +811,15 @@ class TaskDependencyGraph:
                     is_milestone=task.is_milestone,
                     is_on_critical_path=task_id in critical_path_set,
                     total_slack=latest_start_cache[task_id] - (planned_start - self._starting_time_of_run),
+                    free_slack=min(
+                        (
+                            start_cache[s]
+                            for s in self._graph.successors(task_id)
+                            if s not in _ARTIFICIAL_NODE_IDS
+                        ),
+                        default=start_cache[task_node_as_artificial_endnode.id],
+                    )
+                    - planned_finish,
                     predecessor_task_ids=predecessor_ids,
                     successor_task_ids=successor_ids,
                 )

--- a/unittests/test_task_dependency_graph.py
+++ b/unittests/test_task_dependency_graph.py
@@ -62,6 +62,7 @@ from .example_tdgs import (
     task_C,
     task_D,
     task_G,
+    task_H,
     task_H_with_fixed_start_2024_01_02,
     task_I,
     task_J,
@@ -1314,6 +1315,110 @@ class TestScheduleEntryTotalSlack:
         by_id = {e.task_id: e for e in report.entries}
         for task in [short, long_, end]:
             assert by_id[task.id].total_slack == tdg.calculate_total_slack_of_task(task.id)
+
+
+# ---------------------------------------------------------------------------
+# Issue #114 – free_slack on ScheduleEntry
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleEntryFreeSlack:
+    """Tests for free_slack on ScheduleEntry (issue #114).
+
+    Free slack formula:
+        free_slack(t) = min(planned_start(s) for real successors s) - planned_finish(t)
+        (use graph_finish when t has no real successors)
+
+    Key property: free_slack ≤ total_slack; on the critical path both are 0.
+    """
+
+    def test_critical_path_task_has_zero_free_slack(self) -> None:
+        """Tasks on the critical path have free_slack == 0."""
+        short = _node("short", 5)
+        long_ = _node("long", 30)
+        end = _node("end", 5)
+        tdg = TaskDependencyGraph(
+            task_list=[short, long_, end],
+            dependency_list=[_edge(short, end), _edge(long_, end)],
+            starting_time_of_run=_T0,
+        )
+        report = tdg.create_schedule_report()
+        by_id = {e.task_id: e for e in report.entries}
+        assert by_id[long_.id].free_slack == timedelta(0)
+        assert by_id[end.id].free_slack == timedelta(0)
+
+    def test_free_slack_never_exceeds_total_slack(self) -> None:
+        """free_slack ≤ total_slack for every task."""
+        short = _node("short", 5)
+        long_ = _node("long", 30)
+        end = _node("end", 5)
+        tdg = TaskDependencyGraph(
+            task_list=[short, long_, end],
+            dependency_list=[_edge(short, end), _edge(long_, end)],
+            starting_time_of_run=_T0,
+        )
+        report = tdg.create_schedule_report()
+        for entry in report.entries:
+            assert entry.free_slack <= entry.total_slack
+
+    def test_task_with_no_real_successor_uses_graph_finish(self) -> None:
+        """A task with no real successors has free_slack == graph_finish - planned_finish."""
+        a = _node("A", 10)
+        b = _node("B", 10)
+        tdg = TaskDependencyGraph(task_list=[a, b], dependency_list=[], starting_time_of_run=_T0)
+        report = tdg.create_schedule_report()
+        by_id = {e.task_id: e for e in report.entries}
+        # both tasks have no real successor; graph_finish = T0+10; both finish at T0+10
+        assert by_id[a.id].free_slack == timedelta(0)
+        assert by_id[b.id].free_slack == timedelta(0)
+
+    def test_concrete_values_graph_daniel(self) -> None:
+        """Verify exact free_slack for graph_daniel.
+
+        graph_daniel:
+             H(10)----I(10)
+            /              \\
+        G(1)                 L(5)
+           \\               /
+            J(20)----K(20)
+
+        Early starts: G=0, H=1, J=1, I=11, K=21, L=41; finish: G=1, H=11, I=21, J=21, K=41, L=46.
+        free_slack:
+          G: min(start[H], start[J]) - finish[G] = min(1,1) - 1 = 0
+          H: start[I] - finish[H] = 11 - 11 = 0
+          J: start[K] - finish[J] = 21 - 21 = 0
+          I: start[L] - finish[I] = 41 - 21 = 20
+          K: start[L] - finish[K] = 41 - 41 = 0
+          L: graph_finish - finish[L] = 46 - 46 = 0
+        """
+        report = graph_daniel.create_schedule_report()
+        by_id = {e.task_id: e for e in report.entries}
+        assert by_id[task_G.id].free_slack == timedelta(0)
+        assert by_id[task_H.id].free_slack == timedelta(0)
+        assert by_id[task_J.id].free_slack == timedelta(0)
+        assert by_id[task_I.id].free_slack == timedelta(minutes=20)
+        assert by_id[task_K.id].free_slack == timedelta(0)
+        assert by_id[task_L.id].free_slack == timedelta(0)
+
+    def test_free_slack_with_parallel_converge(self) -> None:
+        """Task converging into a later join has positive free_slack."""
+        # A(5) and B(20) both feed C(5).
+        # C starts at T0+20 (waits for B).
+        # free_slack[A] = start[C] - finish[A] = 20 - 5 = 15 min
+        # total_slack[A] = 15 min (same here since C is the only successor)
+        a = _node("A", 5)
+        b = _node("B", 20)
+        c = _node("C", 5)
+        tdg = TaskDependencyGraph(
+            task_list=[a, b, c],
+            dependency_list=[_edge(a, c), _edge(b, c)],
+            starting_time_of_run=_T0,
+        )
+        report = tdg.create_schedule_report()
+        by_id = {e.task_id: e for e in report.entries}
+        assert by_id[a.id].free_slack == timedelta(minutes=15)
+        assert by_id[b.id].free_slack == timedelta(0)
+        assert by_id[c.id].free_slack == timedelta(0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #114

## Summary
- Add `free_slack: timedelta` to `ScheduleEntry`
- Formula: `min(planned_start(s) for real successors s) - planned_finish`, with `graph_finish` as fallback when the task has no real successors
- Computed inline in `create_schedule_report` using `start_cache` (already pre-computed) — no additional DAG traversal
- Key invariant: `free_slack ≤ total_slack`; both are `0` on the critical path

## Breaking change
Any code constructing `ScheduleEntry` directly must supply the new required field.

## Test plan
- [x] `tox -e tests` — 187 passed
- [x] `tox -e linting` — 10.00/10
- [x] `tox -e type_check` — no issues
- New tests verify: critical-path tasks have `free_slack == 0`, `free_slack ≤ total_slack` always holds, correct concrete values for `graph_daniel`, convergent-path scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)