### PR TITLE
docs: remove stale tox references left over from the uv migration

### DIFF
--- a/unittests/test_kroki_svg.py
+++ b/unittests/test_kroki_svg.py
@@ -8,7 +8,6 @@ from taskdependencygraph.plotting.kroki import KrokiClient
 from taskdependencygraph.plotting.protocols import PlotMode, Plotter
 from taskdependencygraph.task_dependency_graph import TaskDependencyGraph
 
-# don't ask; it's some weird type-checking issues (related to our tox setup) that require me to do this ugly import
 from .example_data_for_test_task_dependency_graph import dependency_list_2, task_list_2
 
 


### PR DESCRIPTION
## What

Removes a stale `tox` reference left over from the uv migration. Part of the org-wide cleanup sweep (Tier C).

Closes #146

## Change

`unittests/test_kroki_svg.py:11` carried a comment blaming "our tox setup" for a relative import. But:

- the repo no longer has a `tox.ini`,
- `unittests/` is a proper package (`unittests/__init__.py` exists) and CI type-checks it as one (`uv run --group type_check mypy … unittests --strict`),
- the sibling `unittests/test_task_dependency_graph.py` uses the identical in-package relative import with no comment and no complaint.

So the comment is misleading, not a real constraint. Deleted the comment; kept the import (the normal in-package form).

## Scope / deliberately untouched

- `README.md`'s `pip install taskdependencygraph` is the legitimate end-user install command for the published package — not a stale reference.
- Per the sweep's conventions: historical records under `docs/**/plans/**` and `docs/**/specs/**`, and the `.tox/` line in `.gitignore`, are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
